### PR TITLE
Feature/81 etl timezone issue

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -121,6 +121,7 @@ jobs:
           cf set-env $APP_NAME "DB_PASSWORD" "$DB_PASSWORD" > /dev/null
           cf set-env $APP_NAME "DB_USERNAME" "$DB_USERNAME" > /dev/null
           cf set-env $APP_NAME "GLOSSARY_AUTH" "$GLOSSARY_AUTH" > /dev/null
+          cf set-env $APP_NAME "TZ" "America/New_York" > /dev/null
 
       - name: Configure Public AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -207,6 +208,7 @@ jobs:
           cf set-env $APP_NAME "EQ_USERNAME" "$EQ_USERNAME" > /dev/null
           cf set-env $APP_NAME "EQ_PASSWORD" "$EQ_PASSWORD" > /dev/null
           cf set-env $APP_NAME "GLOSSARY_AUTH" "$GLOSSARY_AUTH" > /dev/null
+          cf set-env $APP_NAME "TZ" "America/New_York" > /dev/null
 
       # Now that front-end is built in server/dist, only push server dir to Cloud.gov
       - name: Deploy application to Cloud.gov

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -135,6 +135,9 @@ export async function createEqDb(client) {
     try {
       // Create the expert_query db
       await client.query('CREATE DATABASE ' + dbName);
+      await client.query(
+        `ALTER DATABASE ${dbName} SET timezone TO 'America/New_York';`,
+      );
       log.info(`${dbName} database created!`);
     } catch (err) {
       log.info(`Warning: ${dbName} database! ${err}`);


### PR DESCRIPTION
## Related Issues:
* [EQ-81](https://jira.epa.gov/browse/EQ-81)

## Main Changes:
* Configure timezones across the app to the same timezone (America/New York). This should help with debugging. Currently, cloud.gov is on Alaska time (4 hours behind EST) and the database is on UTC 0 (4 hours ahead of EST). 


