### PR TITLE
Feature/80 etl gis services

### DIFF
--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -361,9 +361,11 @@ export async function trimSchema(pool) {
   const client = await getClient(pool);
   try {
     const msInDay = 86400000;
-    schemas.rows.forEach(async (schema) => {
-      if (Date.now() - parseInt(schema.date) * 1000 > 5 * msInDay) {
+    for (const index in schemas.rows) {
+      const schema = schemas.rows[index];
+      if (Date.now() - parseFloat(schema.date) * 1000 > 1 * msInDay) {
         try {
+          log.info(`Dropping obsolete schema ${schema.schema_name}`);
           await client.query('BEGIN');
           await client.query(`DROP SCHEMA ${schema.schema_name} CASCADE`);
           await client.query(
@@ -375,7 +377,7 @@ export async function trimSchema(pool) {
           await client.query('ROLLBACK');
         }
       }
-    });
+    }
   } catch (err) {
     log.warn(`Error dropping obsolete schemas: ${err}`);
   } finally {

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -363,7 +363,7 @@ export async function trimSchema(pool) {
     const msInDay = 86400000;
     for (const index in schemas.rows) {
       const schema = schemas.rows[index];
-      if (Date.now() - parseFloat(schema.date) * 1000 > 1 * msInDay) {
+      if (Date.now() - parseFloat(schema.date) * 1000 > 5 * msInDay) {
         try {
           log.info(`Dropping obsolete schema ${schema.schema_name}`);
           await client.query('BEGIN');


### PR DESCRIPTION
## Related Issues:
* [EQ-80](https://jira.epa.gov/browse/EQ-80)

## Main Changes:
* Fixed an issue with deleting obsolete crashing etl. 
    * The problem was the `forEach` callback runs asynchronously, so the connection pool was getting closed before any of the drop statements run.

## Steps To Test:
1. Change the dates in the `creation_date` column of the `etl_schemas` table so they are all older than 5 days old.
2. Run the etl process
3. Verify the old schemas are deleted

