### PR TITLE
Updated setTimeout, added retries for profiles

### DIFF
--- a/etl/app/content-private/services.json
+++ b/etl/app/content-private/services.json
@@ -1,6 +1,6 @@
 {
-    "attainsGis": {
-        "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
-    },
-    "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary"
+  "attainsGis": {
+    "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
+  },
+  "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary"
 }

--- a/etl/app/server/profiles/assessments.js
+++ b/etl/app/server/profiles/assessments.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { setTimeout } from 'timers/promises';
 
 import { logger as log } from '../utilities/logger.js';
 
@@ -69,10 +70,8 @@ export async function extract(s3Config, next = 0, retryCount = 0) {
   if (res.status !== 200) {
     log.info('Non-200 response returned from GIS service, retrying');
     if (retryCount < s3Config.config.retryLimit) {
-      return setTimeout(
-        () => extract(s3Config, next, retryCount + 1),
-        s3Config.config.retryIntervalSeconds * 1000,
-      );
+      await setTimeout(s3Config.config.retryIntervalSeconds * 1000);
+      return await extract(s3Config, next, retryCount + 1);
     } else {
       throw new Error('Retry count exceeded');
     }


### PR DESCRIPTION
## Related Issues:
* [EQ-85](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-85)
* [EQ-86](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-86)

## Main Changes:
* Moved the Postgres `COMMIT` message inside the `while` loop of the profile ETL processes instead of queuing all queries for a single commit.
* Added retry logic to the per-profile ETL processes.
    * Each table will retry its load operation upon failure, up the specified retry count, then the whole process will fail.
* Switched to the promise-based `setTimeout` in two cases where a return type of Promise was expected.
  * Previously, the connection pool would close before the timeout functions would run, crashing the app. This isn't necessary for the `syncGlossary` function or the two timeouts in the Express handlers, because no other functions depend on their resolution.

## Steps To Test:
1. In the `services.json` file, mangle the "attainsGis" URL, then run the application.
2. The console should print "Retrying ETL for table assessments: [err]", then retry after a short wait.
3. After 5 retries, the process should end.
4. Correct the URL, then change line 70 of `assessments.js` to: `if (res.status === 200) {`.
5. The console should print "Non-200 response returned from GIS service, retrying", then retry after a short wait.
6. Undo the last change, run the program as intended, and confirm all rows in the "assessments" table are properly inserted.