### PR TITLE
Feature/109 domains service etl

### DIFF
--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -17,23 +17,26 @@ type Content = {
       lines: string;
       areas: string;
       controlTable: string;
-    },
+    };
     glossaryURL: string;
     attains: {
       serviceUrlDev: string;
       serviceUrl: string;
-    },
+    };
     googleAnalyticsMapping: {
       urlLookup: string;
       wildcardUrl: string;
       name: string;
-    }[]
+    }[];
   };
   alertsConfig: {
     [page: string]: {
       class: string;
       content: string;
-    },
+    };
+  };
+  domainValues: {
+    [field: string]: Option<string, string>[];
   };
 };
 
@@ -69,10 +72,7 @@ function reducer(state: State, action: Action): State {
     }
 
     case "FETCH_CONTENT_SUCCESS": {
-      const {
-        services,
-        alertsConfig,
-      } = action.payload;
+      const { services, alertsConfig, domainValues } = action.payload;
 
       return {
         ...state,
@@ -81,6 +81,7 @@ function reducer(state: State, action: Action): State {
           data: {
             services,
             alertsConfig,
+            domainValues,
           },
         },
       };

--- a/app/client/src/types/custom.d.ts
+++ b/app/client/src/types/custom.d.ts
@@ -1,11 +1,15 @@
-declare module '*.svg' {
-    import * as React from 'react';
-  
-    export const ReactComponent: React.FunctionComponent<React.SVGProps<
-      SVGSVGElement
-    > & { title?: string }>;
-  
-    const src: string;
-    export default src;
-  }
-  
+declare module "*.svg" {
+  import * as React from "react";
+
+  export const ReactComponent: React.FunctionComponent<
+    React.SVGProps<SVGSVGElement> & { title?: string }
+  >;
+
+  const src: string;
+  export default src;
+}
+
+interface Option<S, T> {
+  label: S;
+  value: T;
+}

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -17,7 +17,11 @@ module.exports = function (app) {
     const metadataObj = logger.populateMetdataObjFromRequest(req);
 
     // NOTE: static content files found in `app/server/app/content/` directory
-    const filenames = ["config/services.json", "alerts/config.json"];
+    const filenames = [
+      "content/config/services.json",
+      "content/alerts/config.json",
+      "content-etl/domainValues.json",
+    ];
 
     const s3BucketUrl = `https://${s3Bucket}.s3-${s3Region}.amazonaws.com`;
 
@@ -25,7 +29,7 @@ module.exports = function (app) {
       // local development: read files directly from disk
       // Cloud.gov: fetch files from the public s3 bucket
       return isLocal
-        ? readFile(resolve(__dirname, "../content", filename), "utf8")
+        ? readFile(resolve(__dirname, "../", filename), "utf8")
         : axios({
             method: "get",
             url: `${s3BucketUrl}/content/${filename}`,
@@ -45,6 +49,7 @@ module.exports = function (app) {
         return res.json({
           services: isLocal ? JSON.parse(data[0]) : data[0],
           alertsConfig: isLocal ? JSON.parse(data[1]) : data[1],
+          domainValues: isLocal ? JSON.parse(data[2]) : data[2],
         });
       })
       .catch((error) => {

--- a/etl/app/config/domainValueMappings.js
+++ b/etl/app/config/domainValueMappings.js
@@ -1,0 +1,54 @@
+// Defaults: valueField = 'code', labelField = 'name'
+export default {
+  actionAgency: {
+    domainName: 'AgencyCode',
+  },
+  assessmentUnitStatus: {
+    domainName: 'StatusIndicator',
+    valueField: 'name',
+  },
+  loadAllocationUnits: {
+    domainName: 'LoadAllocationUnitCode',
+  },
+  locationTypeCode: {
+    domainName: 'LocationTypeCode',
+  },
+  locationText: {
+    domainName: 'LocationTypeValue',
+  },
+  organizationId: {
+    domainName: 'OrgStateCode',
+    labelField: 'context',
+    valueField: 'context',
+  },
+  parameterGroup: {
+    domainName: 'ParameterGroupCodeType',
+  },
+  pollutant: {
+    domainName: 'ParameterName',
+  },
+  sourceName: {
+    domainName: 'SourceName',
+  },
+  sourceScale: {
+    domainName: 'SizeSourceScaleText',
+  },
+  sourceType: {
+    domainName: 'PollutantSourceType',
+  },
+  stateIRCategory: {
+    domainName: 'StateIRCategoryCode',
+  },
+  useClassName: {
+    domainName: 'UseClassType',
+    valueField: 'name',
+  },
+  waterSizeUnits: {
+    domainName: 'WaterTypeUnitsCode',
+  },
+  waterType: {
+    domainName: 'WaterTypeUnitsCode',
+    labelField: 'context',
+    valueField: 'context',
+  },
+};

--- a/etl/app/content-private/services.json
+++ b/etl/app/content-private/services.json
@@ -2,5 +2,7 @@
   "attainsGis": {
     "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
   },
-  "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary"
+  "domainValues": "https://attains.epa.gov/attains-public/api/domains",
+  "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary",
+  "stateCodes": "https://attains.epa.gov/attains-public/api/states"
 }

--- a/etl/app/index.js
+++ b/etl/app/index.js
@@ -98,6 +98,8 @@ app.on('tryDb', async () => {
     }, 30 * 1000);
   });
 
+  if (!client) return;
+
   // Create expert_query user
   try {
     await database.createEqDb(client);

--- a/etl/app/index.js
+++ b/etl/app/index.js
@@ -18,15 +18,17 @@ const requiredEnvVars = ['EQ_PASSWORD', 'GLOSSARY_AUTH'];
 if (environment.isLocal) {
   requiredEnvVars.push('DB_USERNAME', 'DB_PASSWORD', 'DB_PORT', 'DB_HOST');
 } else {
-  requiredEnvVars.push('CF_S3_PUB_ACCESS_KEY');
-  requiredEnvVars.push('CF_S3_PUB_BUCKET_ID');
-  requiredEnvVars.push('CF_S3_PUB_REGION');
-  requiredEnvVars.push('CF_S3_PUB_SECRET_KEY');
-  requiredEnvVars.push('CF_S3_PRIV_ACCESS_KEY');
-  requiredEnvVars.push('CF_S3_PRIV_BUCKET_ID');
-  requiredEnvVars.push('CF_S3_PRIV_REGION');
-  requiredEnvVars.push('CF_S3_PRIV_SECRET_KEY');
-  requiredEnvVars.push('VCAP_SERVICES');
+  requiredEnvVars.push(
+    'CF_S3_PUB_ACCESS_KEY',
+    'CF_S3_PUB_BUCKET_ID',
+    'CF_S3_PUB_REGION',
+    'CF_S3_PUB_SECRET_KEY',
+    'CF_S3_PRIV_ACCESS_KEY',
+    'CF_S3_PRIV_BUCKET_ID',
+    'CF_S3_PRIV_REGION',
+    'CF_S3_PRIV_SECRET_KEY',
+    'VCAP_SERVICES',
+  );
 }
 
 requiredEnvVars.forEach((envVar) => {
@@ -52,6 +54,7 @@ async function etlJob(first = false) {
   }
 
   s3.syncGlossary(s3Config);
+  s3.syncDomainValues(s3Config);
 
   // Create and load new schema
   await database.runJob(s3Config, first);


### PR DESCRIPTION
## Related Issues:
* [EQ-109](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-109)

## Main Changes:
* Updated the ETL process to synchronize necessary values from the ATTAINS Domain Values Service to a JSON file in the private S3 bucket.
* The ATTAINS state code/name values are included in the same file.
* Updated the _lookupFiles_ route to include this file in the data provided by the `Content` context.

## Steps To Test:
1. Run the ETL process, then confirm the `domainValues.json` file is written to `app/server/app/content-etl`.
2. Log the contents of `content.data` from the `Content` context to confirm the domain values are included.
3. In the `services.json` file of the ETL process, jumble the URLs of the `domainValues` and `stateCodes` services, then re-run the process to check for proper error handling. For each domain name and for the state codes, there should be 5 retries, then an empty array will be returned instead of ending the process.

## TODO:
- [ ] A static file is used to map field names to domain names, and to designate the proper fields to extract for each. This is located in `etl/app/config`. Should it included with the `content-private` config files?
