### PR TITLE
Feature/88 improve data load performance

### DIFF
--- a/etl/app/content-private/config.json
+++ b/etl/app/content-private/config.json
@@ -1,5 +1,5 @@
 {
-    "chunkSize": 2000,
+    "chunkSize": 20000,
     "retryLimit": 5,
     "retryIntervalSeconds": 5,
     "schemaRetentionDays": 5

--- a/etl/package-lock.json
+++ b/etl/package-lock.json
@@ -15,7 +15,8 @@
         "express": "4.18.2",
         "log4js": "6.7.0",
         "node-cron": "3.0.2",
-        "pg": "8.8.0"
+        "pg": "8.8.0",
+        "pg-promise": "^10.14.0"
       },
       "devDependencies": {
         "browser-sync": "2.27.10",
@@ -326,6 +327,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assert-options": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.7.0.tgz",
+      "integrity": "sha512-7q9uNH/Dh8gFgpIIb9ja8PJEWA5AQy3xnBC8jtKs8K/gNVCr1K6kIvlm59HUyYgvM7oEDoLzGgPcGd9FqhtXEQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/astral-regex": {
@@ -3807,12 +3816,34 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-minify": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.2.tgz",
+      "integrity": "sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg==",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
       "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
       "peerDependencies": {
         "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-promise": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.14.0.tgz",
+      "integrity": "sha512-8Gnzgnyo9DB44gTut9B1sQ0aINNnreA6NJjwtZDEj7PDgpj9g6xs+Af3KMXt9OksmPlleFvVb7YwENHSAJVj6g==",
+      "dependencies": {
+        "assert-options": "0.7.0",
+        "pg": "8.8.0",
+        "pg-minify": "1.6.2",
+        "spex": "3.2.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -4587,6 +4618,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/spex": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.2.0.tgz",
+      "integrity": "sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg==",
+      "engines": {
+        "node": ">=4.5"
+      }
     },
     "node_modules/split2": {
       "version": "4.1.0",
@@ -5578,6 +5617,11 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "assert-options": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.7.0.tgz",
+      "integrity": "sha512-7q9uNH/Dh8gFgpIIb9ja8PJEWA5AQy3xnBC8jtKs8K/gNVCr1K6kIvlm59HUyYgvM7oEDoLzGgPcGd9FqhtXEQ=="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -8111,11 +8155,27 @@
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
+    "pg-minify": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-1.6.2.tgz",
+      "integrity": "sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg=="
+    },
     "pg-pool": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
       "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
       "requires": {}
+    },
+    "pg-promise": {
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-10.14.0.tgz",
+      "integrity": "sha512-8Gnzgnyo9DB44gTut9B1sQ0aINNnreA6NJjwtZDEj7PDgpj9g6xs+Af3KMXt9OksmPlleFvVb7YwENHSAJVj6g==",
+      "requires": {
+        "assert-options": "0.7.0",
+        "pg": "8.8.0",
+        "pg-minify": "1.6.2",
+        "spex": "3.2.0"
+      }
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -8682,6 +8742,11 @@
           "dev": true
         }
       }
+    },
+    "spex": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spex/-/spex-3.2.0.tgz",
+      "integrity": "sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg=="
     },
     "split2": {
       "version": "4.1.0",

--- a/etl/package.json
+++ b/etl/package.json
@@ -39,7 +39,8 @@
     "express": "4.18.2",
     "log4js": "6.7.0",
     "node-cron": "3.0.2",
-    "pg": "8.8.0"
+    "pg": "8.8.0",
+    "pg-promise": "10.14.0"
   },
   "devDependencies": {
     "browser-sync": "2.27.10",


### PR DESCRIPTION
## Related Issues:
* [EQ-88](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-88)

## Main Changes:
* Set tables to `UNLOGGED` while doing batch inserts.
* Switched to multi-value INSERT statements.
* Installed the `pg-promise` library to facilitate the multi-value inserts. This isn't the smallest library, but it's built on top of `node-postgres`, which we already use, so that accounts for some of its size.

## Steps To Test:
1. Run the ETL process, and record its load time, comparing it to the previous table load times.
2. Confirm data is correctly populated.

## TODO:
- [ ] While there is an observable performance boost, the bottleneck now seems to be the HTTP requests. We could "thread" these requests, but then we'd lose all control over the amount of data held in memory. I think it would be better to increase the fetched chunk size once we have control of the remote server. Since table updates are already threaded, we'll need to optimize the chunk size through trial and error. 
