### PR TITLE
Feature/116 organize post inputs

### DIFF
--- a/app/server/app/routes/data.js
+++ b/app/server/app/routes/data.js
@@ -125,6 +125,9 @@ async function executeQuery(profile, req, res) {
       highWaterMark: parseInt(process.env.STREAM_HIGH_WATER_MARK),
     });
 
+    // close the stream if the request is canceled
+    stream.on("close", stream.end.bind(stream));
+
     const format = queryParams.options.format ?? queryParams.options.f;
     switch (format) {
       case "csv":


### PR DESCRIPTION
## Related Issues:
* [EQ-116](https://jira.epa.gov/browse/EQ-116)
* [EQ-117](https://jira.epa.gov/browse/EQ-117)

## Main Changes:
* Added some heirarchy to the post request parameters.
* Added the ability to tell the api to only return certain columns.
* Updated the streaming logic to close the stream if the request is canceled.

## Steps To Test:
1. Test downloading files and verify they each has 4 records and 2 columns in it
    * http://localhost:9090/attains/data/assessments?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle&f=csv
    * http://localhost:9090/attains/data/assessments?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle&f=tsv
    * http://localhost:9090/attains/data/assessments?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle&f=xlsx
    * http://localhost:9090/attains/data/assessments?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle&f=json
2. Naviage to http://localhost:9090/attains/data/assessments?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle and verify that 4 records and 2 columns are displayed
3. Naviage to http://localhost:9090/attains/data/assessments/count?id=1&id=2&id=3&id=4&columns=id&columns=reportingCycle and verify the count is 4
4. Open developer tools and go to console tab
5. Paste the following scripts, for executing POST requests, and verify they work
    * `fetch('http://localhost:9090/attains/data/assessments', {method:'POST',headers:{'content-type':'application/json'}, body: JSON.stringify({filters: { id: [1, 2, 3, 4]}, options: {f: 'json'}, columns: ['id', 'reportingCycle']})}).then((res) => res.json()).then((res) => console.log(res));`
    * `fetch('http://localhost:9090/attains/data/assessments', {method:'POST',headers:{'content-type':'application/json'}, body: JSON.stringify({filters: { id: [1, 2, 3, 4]}, options: {f: 'csv'}, columns: ['id', 'reportingCycle']})}).then((res) => res.text()).then((res) => console.log(res));`

