### PR TITLE
Feature/112 restric access to api endpoints

### DIFF
--- a/app/server/app/index.js
+++ b/app/server/app/index.js
@@ -98,21 +98,6 @@ requiredEnvVars.forEach((envVar) => {
 });
 
 /****************************************************************
-Enable CORS for local environment proxy use
-****************************************************************/
-if (isLocal) {
-  app.use(function (req, res, next) {
-    res.header("Access-Control-Allow-Origin", "*");
-    res.header(
-      "Access-Control-Allow-Headers",
-      "Origin, X-Requested-With, Content-Type, Accept"
-    );
-    res.header("X-Frame-Options", "allow-from http://localhost:3000/");
-    next();
-  });
-}
-
-/****************************************************************
  Setup server and routes
 ****************************************************************/
 // serve static assets normally

--- a/app/server/app/routes/data.js
+++ b/app/server/app/routes/data.js
@@ -1,3 +1,4 @@
+const cors = require("cors");
 const express = require("express");
 const Excel = require("exceljs");
 const { getActiveSchema } = require("../middleware");
@@ -212,22 +213,30 @@ module.exports = function (app) {
 
   router.use(getActiveSchema);
 
+  const corsOptions = {
+    methods: "GET,HEAD,POST",
+  };
+
   Object.entries(mapping).forEach(([profileName, profile]) => {
     // create get requests
-    router.get(`/${profileName}`, function (req, res) {
+    router.get(`/${profileName}`, cors(corsOptions), function (req, res) {
       executeQuery(profile, req, res);
     });
-    router.get(`/${profileName}/count`, function (req, res) {
+    router.get(`/${profileName}/count`, cors(corsOptions), function (req, res) {
       executeQueryCountOnly(profile, req, res);
     });
 
     // create post requests
-    router.post(`/${profileName}`, function (req, res) {
+    router.post(`/${profileName}`, cors(corsOptions), function (req, res) {
       executeQuery(profile, req, res);
     });
-    router.post(`/${profileName}/count`, function (req, res) {
-      executeQueryCountOnly(profile, req, res);
-    });
+    router.post(
+      `/${profileName}/count`,
+      cors(corsOptions),
+      function (req, res) {
+        executeQueryCountOnly(profile, req, res);
+      }
+    );
   });
 
   app.use("/attains/data", router);

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "axios": "1.1.2",
+        "cors": "2.8.5",
         "dotenv": "16.0.3",
         "exceljs": "4.3.0",
         "express": "4.18.2",
@@ -23,8 +24,8 @@
       },
       "devDependencies": {
         "browser-sync": "2.27.10",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-config-prettier": "8.5.0",
+        "eslint-plugin-prettier": "4.2.1",
         "husky": "8.0.1",
         "lint-staged": "13.0.3",
         "nodemon": "2.0.20",
@@ -1230,7 +1231,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -3645,7 +3645,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6507,7 +6506,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
@@ -8342,8 +8340,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
       "version": "1.12.2",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "axios": "1.1.2",
+    "cors": "2.8.5",
     "dotenv": "16.0.3",
     "exceljs": "4.3.0",
     "express": "4.18.2",


### PR DESCRIPTION
## Related Issues:
* [EQ-112](https://jira.epa.gov/browse/EQ-112)

## Main Changes:
* Updated the routes so that `attains/data` is publicly available and all other routes are restricted, such that they only work from expert query.

## Steps To Test:
1. Navigate to http://localhost:3000/attains#format=csv
2. Verify the app loads and the glossary works (this verifies the `api/lookupFiles` call works)
3. Open the console tab in the chrome dev tools
4. Paste script 2 in the console and verify it works
5. Navigate to http://localhost:9090/attains#format=csv
6. Paste script 1 in the console and verify it works
7. Paste script 2 in the console and verify it works
8. Navigate to https://mywaterway.epa.gov/
9. Paste script 1 in the console and verify it returns a CORS error
10. Paste script 2 in the console and verify it works

Testing Scripts
1. `fetch('http://localhost:9090/api/lookupFiles').then(res => res.json()).then(console.log);`
2. `fetch('http://localhost:9090/attains/data/assessments?id=1&id=2').then(res => res.json()).then(console.log);`

