### PR TITLE
Feature/100 etl assessment units

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -178,6 +178,7 @@ jobs:
       EQ_PASSWORD: ${{ secrets.EQ_PASSWORD_DEV }}
       EQ_USERNAME: ${{ secrets.EQ_USER_DEV }}
       GLOSSARY_AUTH: ${{ secrets.GLOSSARY_AUTH }}
+      MV_API_KEY: ${{ secrets.MV_API_KEY }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -210,6 +211,7 @@ jobs:
           cf set-env $APP_NAME "EQ_USERNAME" "$EQ_USERNAME" > /dev/null
           cf set-env $APP_NAME "EQ_PASSWORD" "$EQ_PASSWORD" > /dev/null
           cf set-env $APP_NAME "GLOSSARY_AUTH" "$GLOSSARY_AUTH" > /dev/null
+          cf set-env $APP_NAME "MV_API_KEY" "$MV_API_KEY" > /dev/null
           cf set-env $APP_NAME "TZ" "America/New_York" > /dev/null
 
       - name: Configure Private AWS Credentials

--- a/app/server/app/routes/data.js
+++ b/app/server/app/routes/data.js
@@ -9,8 +9,8 @@ const StreamingService = require("../utilities/streamingService");
 
 // mapping to dynamically build GET/POST endpoints and queries
 const mapping = {
-  assessments: {
-    tableName: "assessments",
+  gisAssessments: {
+    tableName: "gis_assessments",
     idColumn: "id",
     columns: [
       { name: "id", alias: "id" },

--- a/etl/.env.example
+++ b/etl/.env.example
@@ -15,6 +15,9 @@ DB_PASSWORD=
 EQ_USERNAME=
 EQ_PASSWORD=
 
+# materialized view api key
+MV_API_KEY=
+
 # limits the number of chunks imported from service calls
 # this helps limit the amount of data loaded onto the machine
-MAX_CHUNKS=2
+MAX_CHUNKS=

--- a/etl/.env.example
+++ b/etl/.env.example
@@ -14,3 +14,7 @@ DB_PASSWORD=
 # local database read-only user
 EQ_USERNAME=
 EQ_PASSWORD=
+
+# limits the number of chunks imported from service calls
+# this helps limit the amount of data loaded onto the machine
+MAX_CHUNKS=2

--- a/etl/app/content-private/config.json
+++ b/etl/app/content-private/config.json
@@ -1,5 +1,6 @@
 {
-    "chunkSize": 2000,
+    "chunkSize": 10000,
+    "gisChunkSize": 2000,
     "retryLimit": 5,
     "retryIntervalSeconds": 5,
     "schemaRetentionDays": 5

--- a/etl/app/content-private/services.json
+++ b/etl/app/content-private/services.json
@@ -4,5 +4,6 @@
   },
   "domainValues": "https://attains.epa.gov/attains-public/api/domains",
   "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary",
+  "materializedViews": "https://ordspub.epa.gov/ords/attains_eq/",
   "stateCodes": "https://attains.epa.gov/attains-public/api/states"
 }

--- a/etl/app/index.js
+++ b/etl/app/index.js
@@ -13,7 +13,7 @@ const port = process.env.PORT || 3001;
 
 const environment = getEnvironment();
 
-const requiredEnvVars = ['EQ_PASSWORD', 'GLOSSARY_AUTH'];
+const requiredEnvVars = ['EQ_PASSWORD', 'GLOSSARY_AUTH', 'MV_API_KEY'];
 
 if (environment.isLocal) {
   requiredEnvVars.push('DB_USERNAME', 'DB_PASSWORD', 'DB_PORT', 'DB_HOST');

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -380,7 +380,7 @@ export async function trimSchema(pool, s3Config) {
 
 // Get the ETL task for a particular profile
 function getProfileEtl(
-  { createQuery, extract, tableName, transform },
+  { createQuery, extract, maxChunksOverride, tableName, transform },
   s3Config,
 ) {
   return async function (client, schemaName) {
@@ -401,7 +401,7 @@ function getProfileEtl(
       client.query(`ALTER TABLE ${tableName} SET UNLOGGED`);
       let res = await extract(s3Config);
       let chunksProcessed = 0;
-      const maxChunks = process.env.MAX_CHUNKS;
+      const maxChunks = maxChunksOverride ?? process.env.MAX_CHUNKS;
       while (
         res.data !== null &&
         (!maxChunks || (maxChunks && chunksProcessed < maxChunks))

--- a/etl/app/server/profiles/assessmentUnits.js
+++ b/etl/app/server/profiles/assessmentUnits.js
@@ -1,12 +1,7 @@
-import axios from 'axios';
-import crypto from 'crypto';
-import https from 'https';
-import { setTimeout } from 'timers/promises';
+import { extract as innerExtract } from './materializedViewsExtract.js';
 import pgPromise from 'pg-promise';
 
 const pgp = pgPromise({ capSQL: true });
-
-import { logger as log } from '../utilities/logger.js';
 
 /*
 ## Exports
@@ -65,34 +60,12 @@ const insertColumns = new pgp.helpers.ColumnSet([
 // Methods
 
 export async function extract(s3Config, next = 0, retryCount = 0) {
-  const chunkSize = s3Config.config.chunkSize;
-
-  const profileName = 'profile_assessment_units';
-
-  const url =
-    `${s3Config.services.materializedViews}/${profileName}` +
-    `?p_limit=${chunkSize}&p_offset=${next}`;
-
-  const res = await axios.get(url, {
-    headers: { 'API-key': '{887b8dd6-3cc5-4184-8c00-dc2b414f4a83}' },
-    httpsAgent: new https.Agent({
-      // TODO - Remove this when ordspub supports OpenSSL 3.0
-      // This is needed to allow node 18 to talk with ordspub, which does
-      //   not support OpenSSL 3.0
-      secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
-    }),
-  });
-  if (res.status !== 200) {
-    log.info(`Non-200 response returned from ${profileName} service, retrying`);
-    if (retryCount < s3Config.config.retryLimit) {
-      await setTimeout(s3Config.config.retryIntervalSeconds * 1000);
-      return await extract(s3Config, next, retryCount + 1);
-    } else {
-      throw new Error('Retry count exceeded');
-    }
-  }
-  const data = res.data.records.map((record) => record);
-  return { data: data.length ? data : null, next: next + chunkSize };
+  return await innerExtract(
+    'profile_assessment_units',
+    s3Config,
+    next,
+    retryCount,
+  );
 }
 
 export function transform(data) {

--- a/etl/app/server/profiles/assessmentUnits.js
+++ b/etl/app/server/profiles/assessmentUnits.js
@@ -1,0 +1,124 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import https from 'https';
+import { setTimeout } from 'timers/promises';
+import pgPromise from 'pg-promise';
+
+const pgp = pgPromise({ capSQL: true });
+
+import { logger as log } from '../utilities/logger.js';
+
+/*
+## Exports
+*/
+
+// Properties
+
+export const tableName = 'assessment_units';
+
+export const createQuery = `CREATE TABLE IF NOT EXISTS ${tableName}
+  (
+    id SERIAL PRIMARY KEY,
+    assessmentunitid VARCHAR(50) NOT NULL,
+    assessmentunitname VARCHAR(255) NOT NULL,
+    assessmentunitstate VARCHAR(1) NOT NULL,
+    locationdescription VARCHAR(2000) NOT NULL,
+    locationtext VARCHAR(100),
+    locationtypecode VARCHAR(22) NOT NULL,
+    objectid INTEGER NOT NULL,
+    organizationid VARCHAR(30) NOT NULL,
+    organizationname VARCHAR(150) NOT NULL,
+    organizationtype VARCHAR(30) NOT NULL,
+    region VARCHAR(2),
+    reportingcycle NUMERIC(4) NOT NULL,
+    sizesource VARCHAR(100),
+    sourcescale VARCHAR(30) NOT NULL,
+    state VARCHAR(4000),
+    useclassname VARCHAR(50),
+    watersize NUMERIC(18,4) NOT NULL,
+    watersizeunits VARCHAR(15) NOT NULL,
+    watertype VARCHAR(40) NOT NULL
+  )`;
+
+const insertColumns = new pgp.helpers.ColumnSet([
+  { name: 'assessmentunitid' },
+  { name: 'assessmentunitname' },
+  { name: 'assessmentunitstate' },
+  { name: 'locationdescription' },
+  { name: 'locationtext' },
+  { name: 'locationtypecode' },
+  { name: 'objectid' },
+  { name: 'organizationid' },
+  { name: 'organizationname' },
+  { name: 'organizationtype' },
+  { name: 'region' },
+  { name: 'reportingcycle' },
+  { name: 'sizesource' },
+  { name: 'sourcescale' },
+  { name: 'state' },
+  { name: 'useclassname' },
+  { name: 'watersize' },
+  { name: 'watersizeunits' },
+  { name: 'watertype' },
+]);
+
+// Methods
+
+export async function extract(s3Config, next = 0, retryCount = 0) {
+  const chunkSize = s3Config.config.chunkSize;
+
+  const profileName = 'profile_assessment_units';
+
+  const url =
+    `${s3Config.services.materializedViews}/${profileName}` +
+    `?p_limit=${chunkSize}&p_offset=${next}`;
+
+  const res = await axios.get(url, {
+    headers: { 'API-key': '{887b8dd6-3cc5-4184-8c00-dc2b414f4a83}' },
+    httpsAgent: new https.Agent({
+      // TODO - Remove this when ordspub supports OpenSSL 3.0
+      // This is needed to allow node 18 to talk with ordspub, which does
+      //   not support OpenSSL 3.0
+      secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+    }),
+  });
+  if (res.status !== 200) {
+    log.info(`Non-200 response returned from ${profileName} service, retrying`);
+    if (retryCount < s3Config.config.retryLimit) {
+      await setTimeout(s3Config.config.retryIntervalSeconds * 1000);
+      return await extract(s3Config, next, retryCount + 1);
+    } else {
+      throw new Error('Retry count exceeded');
+    }
+  }
+  const data = res.data.records.map((record) => record);
+  return { data: data.length ? data : null, next: next + chunkSize };
+}
+
+export function transform(data) {
+  const rows = [];
+  data.forEach((datum) => {
+    rows.push({
+      assessmentunitid: datum.assessmentunitid,
+      assessmentunitname: datum.assessmentunitname,
+      assessmentunitstate: datum.assessmentunitstate,
+      locationdescription: datum.locationdescription,
+      locationtext: datum.locationtext,
+      locationtypecode: datum.locationtypecode,
+      objectid: datum.objectid,
+      organizationid: datum.organizationid,
+      organizationname: datum.organizationname,
+      organizationtype: datum.organizationtype,
+      region: datum.region,
+      reportingcycle: datum.reportingcycle,
+      sizesource: datum.sizesource,
+      sourcescale: datum.sourcescale,
+      state: datum.state,
+      useclassname: datum.useclassname,
+      watersize: datum.watersize,
+      watersizeunits: datum.watersizeunits,
+      watertype: datum.watertype,
+    });
+  });
+  return pgp.helpers.insert(rows, insertColumns, tableName);
+}

--- a/etl/app/server/profiles/assessmentUnitsMonitoringLocations.js
+++ b/etl/app/server/profiles/assessmentUnitsMonitoringLocations.js
@@ -1,0 +1,100 @@
+import { extract as innerExtract } from './materializedViewsExtract.js';
+import pgPromise from 'pg-promise';
+
+const pgp = pgPromise({ capSQL: true });
+
+/*
+## Exports
+*/
+
+// Properties
+
+export const tableName = 'assessment_units_monitoring_locations';
+
+export const createQuery = `CREATE TABLE IF NOT EXISTS ${tableName}
+  (
+    id SERIAL PRIMARY KEY,
+    assessmentunitid VARCHAR(50) NOT NULL,
+    assessmentunitname VARCHAR(255) NOT NULL,
+    assessmentunitstatus VARCHAR(1) NOT NULL,
+    locationdescription VARCHAR(2000) NOT NULL,
+    monitoringlocationdatalink VARCHAR(255),
+    monitoringlocationid VARCHAR(35),
+    monitoringlocationorgid VARCHAR(30),
+    objectid INTEGER NOT NULL,
+    organizationid VARCHAR(30) NOT NULL,
+    organizationname VARCHAR(150) NOT NULL,
+    organizationtype VARCHAR(30) NOT NULL,
+    region VARCHAR(2),
+    reportingcycle NUMERIC(4) NOT NULL,
+    sizesource VARCHAR(100),
+    sourcescale VARCHAR(30) NOT NULL,
+    state VARCHAR(4000),
+    useclassname VARCHAR(50),
+    watersize NUMERIC(18,4) NOT NULL,
+    watersizeunits VARCHAR(15) NOT NULL,
+    watertype VARCHAR(40) NOT NULL
+  )`;
+
+const insertColumns = new pgp.helpers.ColumnSet([
+  { name: 'assessmentunitid' },
+  { name: 'assessmentunitname' },
+  { name: 'assessmentunitstatus' },
+  { name: 'locationdescription' },
+  { name: 'monitoringlocationdatalink' },
+  { name: 'monitoringlocationid' },
+  { name: 'monitoringlocationorgid' },
+  { name: 'objectid' },
+  { name: 'organizationid' },
+  { name: 'organizationname' },
+  { name: 'organizationtype' },
+  { name: 'region' },
+  { name: 'reportingcycle' },
+  { name: 'sizesource' },
+  { name: 'sourcescale' },
+  { name: 'state' },
+  { name: 'useclassname' },
+  { name: 'watersize' },
+  { name: 'watersizeunits' },
+  { name: 'watertype' },
+]);
+
+// Methods
+
+export async function extract(s3Config, next = 0, retryCount = 0) {
+  return await innerExtract(
+    'profile_assessment_units_monitoring_locations',
+    s3Config,
+    next,
+    retryCount,
+  );
+}
+
+export function transform(data) {
+  const rows = [];
+  data.forEach((datum) => {
+    rows.push({
+      assessmentunitid: datum.assessmentunitid,
+      assessmentunitname: datum.assessmentunitname,
+      assessmentunitstatus: datum.assessmentunitstatus,
+      locationdescription: datum.locationdescription,
+      monitoringlocationdatalink: datum.monitoringlocationdatalink,
+      monitoringlocationid: datum.monitoringlocationid,
+      monitoringlocationorgid: datum.monitoringlocationorgid,
+      objectid: datum.objectid,
+      organizationid: datum.organizationid,
+      organizationname: datum.organizationname,
+      organizationtype: datum.organizationtype,
+      region: datum.region,
+      reportingcycle: datum.reportingcycle,
+      sizesource: datum.sizesource,
+      sourcescale: datum.sourcescale,
+      state: datum.state,
+      useclassname: datum.useclassname,
+      watersize: datum.watersize,
+      watersizeunits: datum.watersizeunits,
+      watertype: datum.watertype,
+    });
+  });
+  return pgp.helpers.insert(rows, insertColumns, tableName);
+}

--- a/etl/app/server/profiles/gisAssessments.js
+++ b/etl/app/server/profiles/gisAssessments.js
@@ -27,6 +27,9 @@ const selectColumns = [
 
 export const tableName = 'gis_assessments';
 
+// load all data
+export const maxChunksOverride = Number.MAX_SAFE_INTEGER;
+
 export const createQuery = `CREATE TABLE IF NOT EXISTS ${tableName}
   (
     id SERIAL PRIMARY KEY,

--- a/etl/app/server/profiles/gisAssessments.js
+++ b/etl/app/server/profiles/gisAssessments.js
@@ -25,7 +25,7 @@ const selectColumns = [
 
 // Properties
 
-export const tableName = 'assessments';
+export const tableName = 'gis_assessments';
 
 export const createQuery = `CREATE TABLE IF NOT EXISTS ${tableName}
   (
@@ -58,12 +58,12 @@ const insertColumns = new pgp.helpers.ColumnSet([
 // Methods
 
 export async function extract(s3Config, next = 0, retryCount = 0) {
-  const chunkSize = s3Config.config.chunkSize;
+  const gisChunkSize = s3Config.config.gisChunkSize;
 
   const baseUrl =
     `${s3Config.services.attainsGis.summary}/query?` +
     'f=pjson&orderByFields=objectid&returnGeometry=false' +
-    `&outFields=${selectColumns.join(',')}&resultRecordCount=${chunkSize}`;
+    `&outFields=${selectColumns.join(',')}&resultRecordCount=${gisChunkSize}`;
 
   const url = baseUrl + `&where=objectid+>=+${next}`;
   const res = await axios.get(url);
@@ -77,7 +77,7 @@ export async function extract(s3Config, next = 0, retryCount = 0) {
     }
   }
   const data = res.data.features.map((feature) => feature.attributes);
-  return { data: data.length ? data : null, next: next + chunkSize };
+  return { data: data.length ? data : null, next: next + gisChunkSize };
 }
 
 export function transform(data) {

--- a/etl/app/server/profiles/index.js
+++ b/etl/app/server/profiles/index.js
@@ -1,2 +1,3 @@
 export * as assessmentUnits from './assessmentUnits.js';
+export * as assessmentUnitsMonitoringLocations from './assessmentUnitsMonitoringLocations.js';
 export * as gisAssessments from './gisAssessments.js';

--- a/etl/app/server/profiles/index.js
+++ b/etl/app/server/profiles/index.js
@@ -1,3 +1,4 @@
 export * as assessmentUnits from './assessmentUnits.js';
 export * as assessmentUnitsMonitoringLocations from './assessmentUnitsMonitoringLocations.js';
 export * as gisAssessments from './gisAssessments.js';
+export * as sources from './sources.js';

--- a/etl/app/server/profiles/index.js
+++ b/etl/app/server/profiles/index.js
@@ -1,1 +1,1 @@
-export * as assessments from './assessments.js';
+export * as gisAssessments from './gisAssessments.js';

--- a/etl/app/server/profiles/index.js
+++ b/etl/app/server/profiles/index.js
@@ -1,1 +1,2 @@
+export * as assessmentUnits from './assessmentUnits.js';
 export * as gisAssessments from './gisAssessments.js';

--- a/etl/app/server/profiles/materializedViewsExtract.js
+++ b/etl/app/server/profiles/materializedViewsExtract.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import https from 'https';
+import { logger as log } from '../utilities/logger.js';
+
+export async function extract(profileName, s3Config, next = 0, retryCount = 0) {
+  const chunkSize = s3Config.config.chunkSize;
+
+  const url =
+    `${s3Config.services.materializedViews}/${profileName}` +
+    `?p_limit=${chunkSize}&p_offset=${next}`;
+
+  const res = await axios.get(url, {
+    headers: { 'API-key': '{887b8dd6-3cc5-4184-8c00-dc2b414f4a83}' },
+    httpsAgent: new https.Agent({
+      // TODO - Remove this when ordspub supports OpenSSL 3.0
+      // This is needed to allow node 18 to talk with ordspub, which does
+      //   not support OpenSSL 3.0
+      secureOptions: crypto.constants.SSL_OP_LEGACY_SERVER_CONNECT,
+    }),
+  });
+  if (res.status !== 200) {
+    log.info(`Non-200 response returned from ${profileName} service, retrying`);
+    if (retryCount < s3Config.config.retryLimit) {
+      await setTimeout(s3Config.config.retryIntervalSeconds * 1000);
+      return await extract(s3Config, next, retryCount + 1);
+    } else {
+      throw new Error('Retry count exceeded');
+    }
+  }
+  const data = res.data.records.map((record) => record);
+  return { data: data.length ? data : null, next: next + chunkSize };
+}

--- a/etl/app/server/profiles/materializedViewsExtract.js
+++ b/etl/app/server/profiles/materializedViewsExtract.js
@@ -11,7 +11,7 @@ export async function extract(profileName, s3Config, next = 0, retryCount = 0) {
     `?p_limit=${chunkSize}&p_offset=${next}`;
 
   const res = await axios.get(url, {
-    headers: { 'API-key': '{887b8dd6-3cc5-4184-8c00-dc2b414f4a83}' },
+    headers: { 'API-key': process.env.MV_API_KEY },
     httpsAgent: new https.Agent({
       // TODO - Remove this when ordspub supports OpenSSL 3.0
       // This is needed to allow node 18 to talk with ordspub, which does

--- a/etl/app/server/profiles/sources.js
+++ b/etl/app/server/profiles/sources.js
@@ -1,0 +1,95 @@
+import { extract as innerExtract } from './materializedViewsExtract.js';
+import pgPromise from 'pg-promise';
+
+const pgp = pgPromise({ capSQL: true });
+
+/*
+## Exports
+*/
+
+// Properties
+
+export const tableName = 'sources';
+
+export const createQuery = `CREATE TABLE IF NOT EXISTS ${tableName}
+  (
+    id SERIAL PRIMARY KEY,
+    assessmentunitid VARCHAR(50) NOT NULL,
+    assessmentunitname VARCHAR(255) NOT NULL,
+    causename VARCHAR(240) NOT NULL,
+    confirmed VARCHAR(1) NOT NULL,
+    epaircategory VARCHAR(5),
+    locationdescription VARCHAR(2000) NOT NULL,
+    objectid INTEGER NOT NULL,
+    organizationid VARCHAR(30) NOT NULL,
+    organizationname VARCHAR(150) NOT NULL,
+    organizationtype VARCHAR(30) NOT NULL,
+    overallstatus VARCHAR(4000),
+    parametergroup VARCHAR(60) NOT NULL,
+    region VARCHAR(2),
+    reportingcycle NUMERIC(4) NOT NULL,
+    sourcename VARCHAR(240) NOT NULL,
+    state VARCHAR(4000),
+    stateircategory VARCHAR(5),
+    watersize NUMERIC(18,4) NOT NULL,
+    watersizeunits VARCHAR(15) NOT NULL,
+    watertype VARCHAR(40) NOT NULL
+  )`;
+
+const insertColumns = new pgp.helpers.ColumnSet([
+  { name: 'assessmentunitid' },
+  { name: 'assessmentunitname' },
+  { name: 'causename' },
+  { name: 'confirmed' },
+  { name: 'epaircategory' },
+  { name: 'locationdescription' },
+  { name: 'objectid' },
+  { name: 'organizationid' },
+  { name: 'organizationname' },
+  { name: 'organizationtype' },
+  { name: 'overallstatus' },
+  { name: 'parametergroup' },
+  { name: 'region' },
+  { name: 'reportingcycle' },
+  { name: 'sourcename' },
+  { name: 'state' },
+  { name: 'stateircategory' },
+  { name: 'watersize' },
+  { name: 'watersizeunits' },
+  { name: 'watertype' },
+]);
+
+// Methods
+
+export async function extract(s3Config, next = 0, retryCount = 0) {
+  return await innerExtract('profile_sources', s3Config, next, retryCount);
+}
+
+export function transform(data) {
+  const rows = [];
+  data.forEach((datum) => {
+    rows.push({
+      assessmentunitid: datum.assessmentunitid,
+      assessmentunitname: datum.assessmentunitname,
+      causename: datum.causename,
+      confirmed: datum.confirmed,
+      epaircategory: datum.epaircategory,
+      locationdescription: datum.locationdescription,
+      objectid: datum.objectid,
+      organizationid: datum.organizationid,
+      organizationname: datum.organizationname,
+      organizationtype: datum.organizationtype,
+      overallstatus: datum.overallstatus,
+      parametergroup: datum.parametergroup,
+      region: datum.region,
+      reportingcycle: datum.reportingcycle,
+      sourcename: datum.sourcename,
+      state: datum.state,
+      stateircategory: datum.stateircategory,
+      watersize: datum.watersize,
+      watersizeunits: datum.watersizeunits,
+      watertype: datum.watertype,
+    });
+  });
+  return pgp.helpers.insert(rows, insertColumns, tableName);
+}


### PR DESCRIPTION
## Related Issues:
* [EQ-99](https://jira.epa.gov/browse/EQ-99)
* [EQ-100](https://jira.epa.gov/browse/EQ-100)
* [EQ-101](https://jira.epa.gov/browse/EQ-101)

## Main Changes:
* Renamed the `assessments` table to `gisAssessments` in preparation for the `assessments` materialized view being made available.
* Added the following materialized views to the ETL process: `assessment_units`, `assessment_units_monitoring_locations`, and `sources`.
  * The `extract` function is basically the same for each of the materialized views, so I moved that out into it's own file.
  * I added a couple of environment variables to the ETL. 
    * MAX_CHUNKS - This will likely only be used for local development, but I could see it being useful for reducing data loaded into dev or stage. Maybe we will want dev to be limited to 1 million records per table and stage is all of the data. I added this mainly so we don't run out of disc space on our computers.
      * I did provide a way to override this on a per profile basis. Currently, we pull in the entire GIS assessments table locally. This is just for testing large amount of data locally for a single table.  
    * MV_API_KEY - This is the api key needed to connect to the materialized views. Reach out to me on teams, if you don't already have this.

## Steps To Test:
1. Update your `etl\app\.env.local` file to include the `MAX_CHUNKS` and `MV_API_KEY` variables. I recommend setting `MAX_CHUNKS` to 2.
2. Run `npm run etl_database` from the etl folder
3. Verify the `assessment_units`, `assessment_units_monitoring_locations`, `gis_assessments`, and `sources` tables are correctly loaded to the database.
4. Run `npm run start` from the app folder
5. Navigate to `http://localhost:9090/attains/data/gisAssessments?id=1&id=2&id=3&id=4`
6. Verify data is displayed

