### PR TITLE
Bugfix/domain task writes on failure

### DIFF
--- a/app/client/src/types/custom.d.ts
+++ b/app/client/src/types/custom.d.ts
@@ -33,7 +33,7 @@ type DomainValues = {
   sourceScale: Array<Option<string, string>>;
   sourceType: Array<Option<string, string>>;
   state: Array<Option<string, string>>;
-  stateIRCategory: Array<Option<string, string>>;
+  stateIrCategory: Array<Option<string, string>>;
   useClassName: Array<Option<string, string>>;
   waterSizeUnits: Array<Option<string, string>>;
   waterType: Array<Option<string, string>>;

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -12,9 +12,6 @@
   "locationTypeCode": {
     "domainName": "LocationTypeCode"
   },
-  "locationText": {
-    "domainName": "LocationTypeValue"
-  },
   "organizationId": {
     "domainName": "OrgStateCode",
     "labelField": "context",

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -35,7 +35,7 @@
   "sourceType": {
     "domainName": "PollutantSourceType"
   },
-  "stateIRCategory": {
+  "stateIrCategory": {
     "domainName": "StateIRCategoryCode"
   },
   "useClassName": {

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -12,6 +12,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const environment = getEnvironment();
 
+const defaultTimeout = 60000;
+
 // Loads etl config from private S3 bucket
 export async function loadConfig() {
   // NOTE: static content files found in `etl/app/content-private/` directory
@@ -131,6 +133,7 @@ function fetchSingleDomain(name, mapping) {
     try {
       const res = await axios.get(
         `${s3Config.services.domainValues}?domainName=${mapping.domainName}`,
+        { timeout: defaultTimeout },
       );
 
       if (res.status !== 200) {
@@ -207,7 +210,9 @@ export async function syncDomainValues(s3Config) {
 // Sync state codes and labels from the states service
 async function fetchStateValues(s3Config, retryCount = 0) {
   try {
-    const res = await axios.get(s3Config.services.stateCodes);
+    const res = await axios.get(s3Config.services.stateCodes, {
+      timeout: defaultTimeout,
+    });
 
     if (res.status !== 200) {
       return await retryRequest(
@@ -260,6 +265,7 @@ export async function syncGlossary(s3Config, retryCount = 0) {
       headers: {
         authorization: `basic ${process.env.GLOSSARY_AUTH}`,
       },
+      timeout: defaultTimeout,
     });
 
     // check response, retry on failure

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -158,7 +158,7 @@ function fetchSingleDomain(name, mapping) {
 
       const output = {};
       output[name] = values;
-      uploadFilePublic(
+      await uploadFilePublic(
         `${name}.json`,
         JSON.stringify(output),
         'content-etl/domainValues',
@@ -234,7 +234,7 @@ async function fetchStateValues(s3Config, retryCount = 0) {
 
     const output = {};
     output.state = states;
-    uploadFilePublic(
+    await uploadFilePublic(
       'state.json',
       JSON.stringify(output),
       'content-etl/domainValues',
@@ -287,7 +287,7 @@ export async function syncGlossary(s3Config, retryCount = 0) {
     });
 
     // upload the glossary.json file
-    uploadFilePublic('glossary.json', JSON.stringify(terms));
+    await uploadFilePublic('glossary.json', JSON.stringify(terms));
   } catch (errOuter) {
     try {
       return await retryRequest('Glossary', retryCount, s3Config, syncGlossary);


### PR DESCRIPTION
## Related Issues:
* [EQ-121](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-121)

## Main Changes:
* Fixed a bug where an failure in a domain service led to an empty array being written to the `domains.json` file.
    * Instead, the file is not written.
* Split the domain values into separate files, so that other domains can update if one fails.
* The files are recombined into the same `domainValues` object in the `Content` context.

## Steps To Test:
1. In the `etl` directory, run the command `npm run etl_domain_values`.
2. Upon success, there should be a `domainValues` sub-directory in the `app/server/app/content-etl` folder. This folder should be populated with with a file for each domain value listed in `domainValueMappings`, as well as an `index.json` file that contains a list of the other files present.
3. Start the client application, and confirm it runs without error.
4. Log the contents of the `Content` context and confirm the `domainValues` are correctly loaded into context.
