### PR TITLE
Feature/118 curl copy box

### DIFF
--- a/app/client/src/components/alert.tsx
+++ b/app/client/src/components/alert.tsx
@@ -38,7 +38,10 @@ export default function Alert({
   if (!icon) styles.push('usa-alert--no-icon');
 
   return (
-    <div className={`usa-alert ${alertStyles.join(' ')}`} role="alert">
+    <div
+      className={`radius-md usa-alert ${alertStyles.join(' ')}`}
+      role="alert"
+    >
       <div className="usa-alert__body">
         {heading && <h4 className="usa-alert__heading">{heading}</h4>}
         <p className="usa-alert__text">{children}</p>

--- a/app/client/src/components/copyBox.tsx
+++ b/app/client/src/components/copyBox.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ReactComponent as Copy } from 'uswds/img/usa-icons/content_copy.svg';
+import Alert from 'components/alert';
 
 type Props = {
+  lengthExceededMessage?: string;
+  maxLength?: number;
   text: string;
 };
 
@@ -9,7 +12,11 @@ const failureMessage = 'Could not access clipboard.';
 
 const successMessage = 'Copied to clipboard!';
 
-export default function CopyBox({ text }: Props) {
+export default function CopyBox({
+  lengthExceededMessage,
+  maxLength,
+  text,
+}: Props) {
   const [status, setStatus] = useState<'success' | 'failure' | 'idle'>('idle');
   const [statusVisible, setStatusVisible] = useState(false);
 
@@ -41,52 +48,60 @@ export default function CopyBox({ text }: Props) {
       });
   }, [text]);
 
-  return (
-    <div className="bg-base-lightest radius-md">
-      <p className="display-flex flex-justify margin-bottom-0 padding-2">
-        <span
-          className="font-mono-sm margin-right-1"
-          style={{ wordBreak: 'break-word' }}
-        >
-          {text}
-        </span>
-        <span className="display-flex">
+  if (maxLength && text.length > maxLength) {
+    return (
+      <Alert type="warning">
+        {lengthExceededMessage ?? 'Maximum character length exceeded'}
+      </Alert>
+    );
+  } else {
+    return (
+      <div className="bg-base-lightest radius-md">
+        <p className="display-flex flex-justify margin-bottom-0 padding-2">
           <span
-            className={`margin-right-1 flex-align-center font-sans-2xs ${
-              statusVisible ? 'display-inline' : 'display-none'
-            } ${status === 'failure' ? 'text-red' : 'text-green'}`}
+            className="font-mono-sm margin-right-1"
+            style={{ wordBreak: 'break-word' }}
           >
-            {status === 'success' ? successMessage : failureMessage}
+            {text}
           </span>
-          <button
-            type="button"
-            className={[
-              'usa-button',
-              'bg-base-lightest',
-              'border-0',
-              'margin-0',
-              'padding-0',
-              'width-auto',
-              'hover:bg-base-lightest',
-            ].join(' ')}
-            onClick={(_ev) => copyToClipboard()}
-            title="Copy content"
-          >
-            <Copy
-              aria-hidden="true"
+          <span className="display-flex flex-justify-end width-card">
+            <span
+              className={`margin-right-1 flex-align-center font-sans-2xs ${
+                statusVisible ? 'display-inline' : 'display-none'
+              } ${status === 'failure' ? 'text-red' : 'text-green'}`}
+            >
+              {status === 'success' ? successMessage : failureMessage}
+            </span>
+            <button
+              type="button"
               className={[
-                'usa-icon',
-                'text-primary',
-                'focus:text-primary-dark',
-                'hover:text-primary-dark',
+                'usa-button',
+                'bg-base-lightest',
+                'border-0',
+                'margin-0',
+                'padding-0',
+                'width-auto',
+                'hover:bg-base-lightest',
               ].join(' ')}
-              focusable="false"
-              role="img"
-            />
-            <span className="sr-only">Copy content</span>
-          </button>
-        </span>
-      </p>
-    </div>
-  );
+              onClick={(_ev) => copyToClipboard()}
+              title="Copy content"
+            >
+              <Copy
+                aria-hidden="true"
+                className={[
+                  'usa-icon',
+                  'text-primary',
+                  'focus:text-primary-dark',
+                  'hover:text-primary-dark',
+                ].join(' ')}
+                focusable="false"
+                role="img"
+              />
+              <span className="sr-only">Copy content</span>
+            </button>
+          </span>
+        </p>
+      </div>
+    );
+  }
 }

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -518,11 +518,11 @@ export function Home() {
               />
               <h4>cURL</h4>
               <CopyBox
-                text={`curl -X POST --json '${JSON.stringify(
+                text={`curl -X POST --json "${JSON.stringify(
                   buildPostData(queryParams),
-                )}' ${origin}${window.location.pathname}/data/${
-                  profiles[dataProfile.value].resource
-                }`}
+                ).replaceAll('"', '\\"')}" ${origin}${
+                  window.location.pathname
+                }/data/${profiles[dataProfile.value].resource}`}
               />
             </>
           )}

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -389,6 +389,11 @@ export function Home() {
   const pathParts = window.location.pathname.split('/');
   const pageName = pathParts.length > 1 ? pathParts[1] : '';
 
+  let origin = window.location.origin;
+  if (window.location.hostname === 'localhost') {
+    origin = `${window.location.protocol}//${window.location.hostname}:9090`;
+  }
+
   if (content.status === 'pending') return <Loading />;
 
   if (content.status === 'failure') {
@@ -499,17 +504,15 @@ export function Home() {
                 <GlossaryTerm term="Acidity">Current Query</GlossaryTerm>
               </h4>
               <CopyBox
-                text={`${window.location.origin}${
-                  window.location.pathname
-                }/#${buildQueryString(queryParams)}`}
+                text={`${origin}${window.location.pathname}/#${buildQueryString(
+                  queryParams,
+                )}`}
               />
               <h4>{profiles[dataProfile.value].label} API Query</h4>
               <CopyBox
                 lengthExceededMessage="The GET request for this query exceeds the maximum URL character length. Please use a POST request instead (see the cURL query below)."
                 maxLength={2048}
-                text={`${window.location.origin}${
-                  window.location.pathname
-                }/data/${
+                text={`${origin}${window.location.pathname}/data/${
                   profiles[dataProfile.value].resource
                 }?${buildQueryString(queryParams, false)}`}
               />
@@ -517,7 +520,7 @@ export function Home() {
               <CopyBox
                 text={`curl -X POST --json '${JSON.stringify(
                   buildPostData(queryParams),
-                )}' ${window.location.origin}${window.location.pathname}/data/${
+                )}' ${origin}${window.location.pathname}/data/${
                   profiles[dataProfile.value].resource
                 }`}
               />


### PR DESCRIPTION
## Related Issues:
* [EQ-118](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-118)

## Main Changes:
* Added a formatted **cURL** command to the list of copy-able queries at the bottom of the page.
* Added a warning to notify users if the GET request exceeds 2048 characters. The user is directed to use a POST request instead.

## Steps To Test:
1. Navigate to the application's home page: [http://localhost:3000/attains](http://localhost:3000/attains).
2. Select a data profile, then select a list of states from the _State_ input.
3. Confirm that the content in the _cURL_ copy box updates to match the input state.
4. Confirm that the command displayed fetches the correct results. For development, **3000** needs to be updated to match the server port (**9090**)