### PR TITLE
Feature/173 reporting cycle latest per organization

### DIFF
--- a/app/server/app/routes/data.js
+++ b/app/server/app/routes/data.js
@@ -27,7 +27,8 @@ function appendLatestToWhere(query, column, columnType, baseQuery) {
   if (columnType !== 'numeric' && columnType !== 'timestamptz') return;
 
   const subQuery = baseQuery.clone();
-  query.where(column, subQuery.max(column));
+  subQuery.select('organizationid').max(column).groupBy('organizationid');
+  query.whereIn(['organizationid', column], subQuery);
 }
 
 /**


### PR DESCRIPTION
## Related Issues:
* [EQ-173](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=865&view=detail&selectedIssue=EQ-173)

## Main Changes:
* This only changes the subquery used in `appendLatestToWhere` in _etl/app/server/database.js_. It's really just a copy and paste of the suggestion proposed in a [previous discussion](https://github.com/Eastern-Research-Group/expert-query/pull/44#discussion_r1091086452) (@cschwinderg feel free to assign the Jira task to yourself).

## Steps To Test:
1. Comment out the lines:
```
  subQuery.select('organizationid').max(column).groupBy('organizationid');
  query.whereIn(['organizationid', column], subQuery);
```
Replace them with the previous logic:
```
  query.where(column, subQuery.max(column));
```
3. Click the **Download** button with a profile selected that has a **Reporting Cycle** field, e.g. http://localhost:3000/attains/assessmentUnits.
4. Take note of the count returned, then click **Cancel**.
5. Revert the steps taken in step 1.
6. Click the **Download** button again, and note the count returned.
7. The latter count should be greater than the former.

## TODO:
- [x] Due to the numerous changes in #49, I forked this from that branch, so we should probably address that and get it merged in first.