### PR TITLE
Feature/190 correct usesupport values

### DIFF
--- a/app/client/src/components/checkboxes.tsx
+++ b/app/client/src/components/checkboxes.tsx
@@ -18,7 +18,7 @@ export function Checkboxes({
 }: CheckboxesProps) {
   return (
     <fieldset className={`usa-fieldset ${styles.join(' ')}`}>
-      {legend && <legend className="usa-legend">{legend}</legend>}
+      {legend && <legend className="margin-top-0 usa-legend">{legend}</legend>}
       {options.map((option, i) => {
         return (
           <Checkbox

--- a/app/client/src/config/fields.ts
+++ b/app/client/src/config/fields.ts
@@ -2,6 +2,7 @@ export const filterFields = [
   { key: 'actionAgency', label: 'Action Agency', type: 'multiselect' },
   { key: 'actionId', label: 'Action ID', type: 'multiselect' },
   { key: 'actionName', label: 'Action Name', type: 'multiselect' },
+  { key: 'actionType', label: 'Action Type', type: 'multiselect' },
   {
     key: 'addressedParameter',
     label: 'Addressed Parameter',

--- a/app/client/src/config/options.tsx
+++ b/app/client/src/config/options.tsx
@@ -82,6 +82,4 @@ export const organizationType = [
 
 export const pollutantIndicator = yesNo;
 
-export const useSupport = yesNo;
-
 export const vision303dPriority = yesNo;

--- a/app/client/src/config/profiles.ts
+++ b/app/client/src/config/profiles.ts
@@ -5,6 +5,7 @@ export default {
       'actionAgency',
       'actionId',
       'actionName',
+      'actionType',
       'assessmentUnitId',
       'assessmentUnitName',
       'completionDateLo',

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -989,6 +989,7 @@ function addDomainAliases(values: DomainOptions): Required<DomainOptions> {
     ...values,
     associatedActionAgency: values.actionAgency,
     associatedActionStatus: values.assessmentUnitStatus,
+    associatedActionType: values.actionType,
     parameter: values.parameterName,
     parameterStateIrCategory: values.stateIrCategory,
     pollutant: values.parameterName,

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -12,6 +12,7 @@ declare global {
 export type AliasedField =
   | 'associatedActionAgency'
   | 'associatedActionStatus'
+  | 'associatedActionType'
   | 'parameter'
   | 'parameterStateIrCategory'
   | 'pollutant'
@@ -24,6 +25,7 @@ export type AliasedOptions = {
 // Fields provided in the `domainValues` of the Content context
 export type ConcreteField =
   | 'actionAgency'
+  | 'actionType'
   | 'assessmentTypes'
   | 'assessmentUnitStatus'
   | 'delistedReason'

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -38,6 +38,7 @@ export type ConcreteField =
   | 'stateIrCategory'
   | 'useClassName'
   | 'useName'
+  | 'useSupport'
   | 'waterType';
 
 type ConcreteOptions = {

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -49,6 +49,9 @@
   "useName": {
     "domainName": "UseName"
   },
+  "useSupport": {
+    "domainName": "UseAttainmentCode"
+  },
   "waterType": {
     "domainName": "WaterTypeUnitsCode",
     "labelField": "context",

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -2,6 +2,10 @@
   "actionAgency": {
     "domainName": "AgencyCode"
   },
+  "actionType": {
+    "domainName": "ActionType",
+    "labelField": "code"
+  },
   "assessmentTypes": {
     "domainName": "AssessmentTypeCode"
   },


### PR DESCRIPTION
## Related Issues:
* [EQ-190](https://jira.epa.gov/browse/EQ-190)

## Main Changes:
* Switched to pulling options for the `usesupport` field from the _UseAttainmentCode_ domain value service. The field was incorrectly displaying only the values "yes" and "no".

## Steps To Test:
1. In the `etl` directory, update the domain values with `npm run etl_domain_values`.
2. Start the client application and navigate to http://localhost:3000/attains/assessments.
3. Confirm that four options are listed for the field "Use Support", and that the inputs have proper values (F, I, X, N).