### PR TITLE
Feature/164 national downloads page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ database/docker/server/postgres/data/
 
 # EQ ETL Bucket
 app/server/app/content-etl/
+app/server/app/national-downloads/

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -347,7 +347,7 @@
         <div class="l-constrain">
           <div class="l-page__header">
             <div class="l-page__header-first">
-              <div class="web-area-title">Expert Query</div>
+              <h1 class="web-area-title">Expert Query</h1>
             </div>
             <div class="l-page__header-last">
               <a
@@ -594,7 +594,9 @@
                   href="https://www.facebook.com/EPA"
                 >
                   <svg class="icon icon--social" aria-hidden="true">
-                    <use href="%PUBLIC_URL%/img/sprite.artifact.svg#facebook-square" />
+                    <use
+                      href="%PUBLIC_URL%/img/sprite.artifact.svg#facebook-square"
+                    />
                   </svg>
                 </a>
               </li>
@@ -605,7 +607,9 @@
                   href="https://twitter.com/epa"
                 >
                   <svg class="icon icon--social" aria-hidden="true">
-                    <use href="%PUBLIC_URL%/img/sprite.artifact.svg#twitter-square" />
+                    <use
+                      href="%PUBLIC_URL%/img/sprite.artifact.svg#twitter-square"
+                    />
                   </svg>
                 </a>
               </li>
@@ -616,7 +620,9 @@
                   href="https://www.youtube.com/user/USEPAgov"
                 >
                   <svg class="icon icon--social" aria-hidden="true">
-                    <use href="%PUBLIC_URL%/img/sprite.artifact.svg#youtube-square" />
+                    <use
+                      href="%PUBLIC_URL%/img/sprite.artifact.svg#youtube-square"
+                    />
                   </svg>
                 </a>
               </li>
@@ -627,7 +633,9 @@
                   href="https://www.flickr.com/photos/usepagov"
                 >
                   <svg class="icon icon--social" aria-hidden="true">
-                    <use href="%PUBLIC_URL%/img/sprite.artifact.svg#flickr-square" />
+                    <use
+                      href="%PUBLIC_URL%/img/sprite.artifact.svg#flickr-square"
+                    />
                   </svg>
                 </a>
               </li>
@@ -638,7 +646,9 @@
                   href="https://www.instagram.com/epagov"
                 >
                   <svg class="icon icon--social" aria-hidden="true">
-                    <use href="%PUBLIC_URL%/img/sprite.artifact.svg#instagram-square" />
+                    <use
+                      href="%PUBLIC_URL%/img/sprite.artifact.svg#instagram-square"
+                    />
                   </svg>
                 </a>
               </li>

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -5,6 +5,7 @@ import 'uswds/css/uswds.css';
 import 'bootstrap/dist/css/bootstrap-grid.min.css';
 // components
 import { Home, QueryBuilder } from 'routes/home';
+import NationalDownloads from 'routes/nationalDownloads';
 import ErrorPage from 'routes/404';
 import { MarkdownContent } from 'components/markdownContent';
 // contexts
@@ -120,6 +121,7 @@ export function App() {
         <Route path="/attains" element={<Home />}>
           <Route path=":profile" element={<QueryBuilder />} />
         </Route>
+        <Route path="/national-downloads" element={<NationalDownloads />} />
         <Route path="/404" element={<ErrorPage />} />
         <Route path="*" element={<ErrorPage />} />
       </Routes>

--- a/app/client/src/components/downloadModal.tsx
+++ b/app/client/src/components/downloadModal.tsx
@@ -17,7 +17,6 @@ import type { FetchState, Primitive, Status } from 'types';
 
 export function DownloadModal<D extends PostData>({
   dataId,
-  disabled = false,
   downloadStatus,
   filename,
   maxCount = Infinity,
@@ -34,7 +33,6 @@ export function DownloadModal<D extends PostData>({
   // Get the row count for the current query
   useEffect(() => {
     if (!queryUrl) return;
-    if (disabled) return;
 
     const countUrl = `${queryUrl}/count`;
     setCount({ status: 'pending', data: null });
@@ -46,7 +44,7 @@ export function DownloadModal<D extends PostData>({
         console.error(err);
         setCount({ status: 'failure', data: null });
       });
-  }, [disabled, queryData, queryUrl]);
+  }, [queryData, queryUrl]);
 
   // Retrieve the requested data in the specified format
   const executeQuery = useCallback(() => {
@@ -85,63 +83,68 @@ export function DownloadModal<D extends PostData>({
       <div className="usa-modal__content">
         <div className="usa-modal__main">
           <h2 className="usa-modal__heading">Download Status</h2>
-          {disabled ? (
-            <CountExceededContent dataId={dataId} />
-          ) : (
+          {count.status === 'pending' && (
+            <div className="usa-prose">
+              <p>Validating query, please wait...</p>
+            </div>
+          )}
+          {count.status === 'failure' && (
+            <Alert type="error">
+              The specified query could not be executed at this time.
+            </Alert>
+          )}
+          {count.status === 'success' && (
             <>
-              {count.status === 'pending' && (
-                <div className="usa-prose">
-                  <p>Validating query, please wait...</p>
-                </div>
-              )}
-              {count.status === 'failure' && (
-                <Alert type="error">
-                  The specified query could not be executed at this time.
+              {count.data > maxCount ? (
+                <Alert type="warning">
+                  <p>The current query exceeds the maximum query size.</p>{' '}
+                  <p>
+                    Please refine the search or visit the{' '}
+                    <a
+                      href={`/national-downloads${dataId ? '#' + dataId : ''}`}
+                    >
+                      National Downloads
+                    </a>{' '}
+                    page to download a compressed dataset.
+                  </p>
                 </Alert>
-              )}
-              {count.status === 'success' && (
+              ) : (
                 <>
-                  {count.data > maxCount ? (
-                    <CountExceededContent dataId={dataId} />
-                  ) : (
-                    <>
-                      <div className="usa-prose">
-                        <p>
-                          Your query will return{' '}
-                          <strong data-testid="downloadfile-length">
-                            {count.data.toLocaleString()}
-                          </strong>{' '}
-                          rows.
-                        </p>
-                        <p>Click continue to download the data.</p>
-                      </div>
-                      <div className="usa-modal__footer">
-                        <ul className="flex-justify-center usa-button-group">
-                          <li className="usa-button-group__item">
-                            <button
-                              type="button"
-                              className="usa-button"
-                              onClick={onClose}
-                            >
-                              Cancel
-                            </button>
-                          </li>
-                          <li className="usa-button-group__item">
-                            <button
-                              className="usa-button"
-                              disabled={count.data === 0}
-                              onClick={executeQuery}
-                              type="button"
-                            >
-                              {downloadStatus === 'pending'
-                                ? 'Working...'
-                                : 'Continue'}
-                            </button>
-                          </li>
-                        </ul>
-                      </div>
-                    </>
-                  )}
+                  <div className="usa-prose">
+                    <p>
+                      Your query will return{' '}
+                      <strong data-testid="downloadfile-length">
+                        {count.data.toLocaleString()}
+                      </strong>{' '}
+                      rows.
+                    </p>
+                    <p>Click continue to download the data.</p>
+                  </div>
+                  <div className="usa-modal__footer">
+                    <ul className="flex-justify-center usa-button-group">
+                      <li className="usa-button-group__item">
+                        <button
+                          type="button"
+                          className="usa-button"
+                          onClick={onClose}
+                        >
+                          Cancel
+                        </button>
+                      </li>
+                      <li className="usa-button-group__item">
+                        <button
+                          className="usa-button"
+                          disabled={count.data === 0}
+                          onClick={executeQuery}
+                          type="button"
+                        >
+                          {downloadStatus === 'pending'
+                            ? 'Working...'
+                            : 'Continue'}
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
                 </>
               )}
             </>
@@ -165,28 +168,12 @@ export function DownloadModal<D extends PostData>({
   );
 }
 
-function CountExceededContent({ dataId }: { dataId?: string }) {
-  return (
-    <Alert type="warning">
-      <p>The current query exceeds the maximum query size.</p>{' '}
-      <p>
-        Please refine the search or visit the{' '}
-        <a href={`/national-downloads${dataId ? '#' + dataId : ''}`}>
-          National Downloads
-        </a>{' '}
-        page to download a compressed dataset.
-      </p>
-    </Alert>
-  );
-}
-
 /*
 ## Types
 */
 
 type DownloadModalProps<D extends PostData> = {
   dataId?: string;
-  disabled?: boolean;
   downloadStatus: Status;
   filename: string | null;
   maxCount?: number;

--- a/app/client/src/components/navButton.tsx
+++ b/app/client/src/components/navButton.tsx
@@ -1,0 +1,48 @@
+import type { FunctionComponent, MouseEventHandler, SVGProps } from 'react';
+
+type NavButtonProps = {
+  icon: FunctionComponent<SVGProps<SVGSVGElement>>;
+  label: string;
+  onClick?: MouseEventHandler;
+  styles?: string[];
+};
+
+export function NavButton({
+  icon,
+  label,
+  onClick = () => {},
+  styles = [],
+}: NavButtonProps) {
+  const buttonStyles = [
+    'margin-bottom-2',
+    'bg-white',
+    'border-2px',
+    'border-transparent',
+    'padding-1',
+    'radius-md',
+    'width-auto',
+    'hover:bg-white',
+    'hover:border-primary',
+    ...styles,
+  ].join(' ');
+
+  const Icon = icon;
+
+  return (
+    <button
+      title={label}
+      className={buttonStyles}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+      type="button"
+    >
+      <Icon
+        aria-hidden="true"
+        className="height-2 margin-right-1 text-primary top-2px usa-icon width-2"
+        focusable="false"
+        role="img"
+      />
+      <span className="font-ui-md text-bold text-primary">{label}</span>
+    </button>
+  );
+}

--- a/app/client/src/config/index.tsx
+++ b/app/client/src/config/index.tsx
@@ -2,11 +2,12 @@ export * as fields from './fields';
 export * as options from './options';
 export { profiles } from './profiles';
 
-const { NODE_ENV, REACT_APP_CLOUD_SPACE, REACT_APP_SERVER_BASE_PATH } = process.env;
+const { NODE_ENV, REACT_APP_CLOUD_SPACE, REACT_APP_SERVER_BASE_PATH } =
+  process.env;
 
 // allows the app to be accessed from a sub directory of a server (e.g. /expertquery)
 export const serverBasePath =
-  NODE_ENV === "local" ? "" : REACT_APP_SERVER_BASE_PATH || "";
+  NODE_ENV === 'local' ? '' : REACT_APP_SERVER_BASE_PATH || '';
 
 // NOTE: This app is configured to use [Create React App's proxy setup]
 // (https://create-react-app.dev/docs/proxying-api-requests-in-development/)

--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -34,6 +34,7 @@ export type Content = {
   }>;
   parameters: {
     debounceMilliseconds: number;
+    maxQuerySize: number;
   };
 };
 

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -179,10 +179,6 @@ export function QueryBuilder() {
       {downloadConfirmationVisible && (
         <DownloadModal
           dataId="attains"
-          disabled={
-            !profiles[profile].columns.has('reportingCycle') &&
-            Object.keys(queryParams.filters).length === 0
-          }
           filename={profile && format ? `${profile}.${format.value}` : null}
           downloadStatus={downloadStatus}
           maxCount={maxQuerySize}

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1,12 +1,5 @@
 import { debounce } from 'lodash';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import {
   Outlet,
   useNavigate,
@@ -16,6 +9,7 @@ import {
 import Select from 'react-select';
 import { ReactComponent as Book } from 'uswds/img/usa-icons/local_library.svg';
 import { ReactComponent as Download } from 'uswds/img/usa-icons/file_download.svg';
+import { ReactComponent as Folder } from 'uswds/img/usa-icons/folder.svg';
 // components
 import { Accordion, AccordionItem } from 'components/accordion';
 import { Alert } from 'components/alert';
@@ -41,8 +35,17 @@ import {
   profiles,
   serverUrl,
 } from 'config';
+// utils
+import { isAbort, useAbort } from 'utils';
 // types
-import type { ChangeEvent, Dispatch, SetStateAction } from 'react';
+import type {
+  ChangeEvent,
+  Dispatch,
+  FunctionComponent,
+  MouseEvent,
+  SetStateAction,
+  SVGProps,
+} from 'react';
 import type { DomainOptions, Option, Primitive, Status } from 'types';
 import type { Profile } from 'config/profiles';
 
@@ -53,6 +56,8 @@ import type { Profile } from 'config/profiles';
 export default Home;
 
 export function Home() {
+  const navigate = useNavigate();
+
   const { content } = useContentState();
 
   const staticOptions = useStaticOptions(content);
@@ -89,22 +94,20 @@ export function Home() {
   if (content.status === 'success') {
     return (
       <>
-        <button
-          title="Glossary"
-          className="js-glossary-toggle margin-bottom-2 bg-white border-2px border-transparent padding-1 radius-md width-auto hover:bg-white hover:border-primary"
-          style={{ cursor: 'pointer' }}
-          type="button"
-        >
-          <Book
-            aria-hidden="true"
-            className="height-2 margin-right-1 text-primary top-2px usa-icon width-2"
-            focusable="false"
-            role="img"
-          />
-          <span className="font-ui-md text-bold text-primary">Glossary</span>
-        </button>
+        <NavButton
+          label="Glossary"
+          icon={Book}
+          styles={['js-glossary-toggle']}
+        />
+        <NavButton
+          label="National Downloads"
+          icon={Folder}
+          onClick={() => navigate('/national-downloads')}
+        />
         <GlossaryPanel path={getPageName()} />
         <div>
+          <h2>Query ATTAINS Data</h2>
+          <hr />
           <ParameterErrorAlert parameters={queryParamErrors} />
           <Intro />
           {staticOptions && (
@@ -513,6 +516,46 @@ function Intro() {
   );
 }
 
+function NavButton({
+  icon,
+  label,
+  onClick = () => {},
+  styles = [],
+}: NavButtonProps) {
+  const buttonStyles = [
+    'margin-bottom-2',
+    'bg-white',
+    'border-2px',
+    'border-transparent',
+    'padding-1',
+    'radius-md',
+    'width-auto',
+    'hover:bg-white',
+    'hover:border-primary',
+    ...styles,
+  ].join(' ');
+
+  const Icon = icon;
+
+  return (
+    <button
+      title={label}
+      className={buttonStyles}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+      type="button"
+    >
+      <Icon
+        aria-hidden="true"
+        className="height-2 margin-right-1 text-primary top-2px usa-icon width-2"
+        focusable="false"
+        role="img"
+      />
+      <span className="font-ui-md text-bold text-primary">{label}</span>
+    </button>
+  );
+}
+
 function ParameterErrorAlert({
   parameters,
 }: {
@@ -758,33 +801,6 @@ function SelectFilter<
 /*
 ## Hooks
 */
-
-function useAbort() {
-  const abortController = useRef(new AbortController());
-  const getAbortController = useCallback(() => {
-    if (abortController.current.signal.aborted) {
-      abortController.current = new AbortController();
-    }
-    return abortController.current;
-  }, []);
-
-  const abort = useCallback(() => {
-    getAbortController().abort();
-  }, [getAbortController]);
-
-  useEffect(() => {
-    return function cleanup() {
-      abortController.current.abort();
-    };
-  }, [getAbortController]);
-
-  const getSignal = useCallback(
-    () => getAbortController().signal,
-    [getAbortController],
-  );
-
-  return { abort, getSignal };
-}
 
 function useClearConfirmationVisibility() {
   const [clearConfirmationVisible, setClearConfirmationVisible] =
@@ -1496,11 +1512,6 @@ async function getUrlInputs(
   return { filters: newState, errors };
 }
 
-function isAbort(error: unknown) {
-  if (!error || typeof error !== 'object' || !('name' in error)) return false;
-  return (error as Error).name === 'AbortError';
-}
-
 // Type narrowing
 function isDateField(field: string): field is DateField {
   return (dateFields as string[]).includes(field);
@@ -1852,6 +1863,13 @@ type MultiOptionState = ReadonlyArray<Option> | null;
 type MultiSelectFilterProps = SelectFilterProps<
   Extract<FilterField, MultiOptionField>
 >;
+
+type NavButtonProps = {
+  icon: FunctionComponent<SVGProps<SVGSVGElement>>;
+  label: string;
+  onClick?: (ev: MouseEvent) => void;
+  styles?: string[];
+};
 
 type OptionInputHandler = (
   option: SingleOptionState | MultiOptionState,

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -21,6 +21,7 @@ import { InfoTooltip } from 'components/infoTooltip';
 import { Loading } from 'components/loading';
 import { DownloadModal } from 'components/downloadModal';
 import { ClearSearchModal } from 'components/clearSearchModal';
+import { NavButton } from 'components/navButton';
 import { RadioButtons } from 'components/radioButtons';
 import { SourceSelect } from 'components/sourceSelect';
 import { Summary } from 'components/summary';
@@ -38,14 +39,7 @@ import {
 // utils
 import { isAbort, useAbort } from 'utils';
 // types
-import type {
-  ChangeEvent,
-  Dispatch,
-  FunctionComponent,
-  MouseEvent,
-  SetStateAction,
-  SVGProps,
-} from 'react';
+import type { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import type { DomainOptions, Option, Primitive, Status } from 'types';
 import type { Profile } from 'config/profiles';
 
@@ -97,7 +91,7 @@ export function Home() {
         <NavButton
           label="Glossary"
           icon={Book}
-          styles={['js-glossary-toggle']}
+          styles={['js-glossary-toggle', 'margin-right-05']}
         />
         <NavButton
           label="National Downloads"
@@ -129,6 +123,7 @@ export function Home() {
                     filterState,
                     format,
                     formatHandler,
+                    maxQuerySize: content.data.parameters.maxQuerySize,
                     profile,
                     queryParams,
                     queryUrl: eqDataUrl,
@@ -157,6 +152,7 @@ export function QueryBuilder() {
     filterState,
     format,
     formatHandler,
+    maxQuerySize,
     profile,
     resetFilters,
     sourceHandlers,
@@ -182,8 +178,14 @@ export function QueryBuilder() {
     <>
       {downloadConfirmationVisible && (
         <DownloadModal
+          dataId="attains"
+          disabled={
+            !profiles[profile].columns.has('reportingCycle') &&
+            Object.keys(queryParams.filters).length === 0
+          }
           filename={profile && format ? `${profile}.${format.value}` : null}
           downloadStatus={downloadStatus}
+          maxCount={maxQuerySize}
           onClose={closeDownloadConfirmation}
           queryData={queryParams}
           queryUrl={
@@ -221,7 +223,7 @@ export function QueryBuilder() {
               legend={
                 <>
                   <b className="margin-right-05">File Format</b>
-                  <InfoTooltip text="Choose a file format for the result set" />
+                  <InfoTooltip text="Choose a file format for the result set." />
                 </>
               }
               onChange={formatHandler}
@@ -513,46 +515,6 @@ function Intro() {
         </button>
       </div>
     </Summary>
-  );
-}
-
-function NavButton({
-  icon,
-  label,
-  onClick = () => {},
-  styles = [],
-}: NavButtonProps) {
-  const buttonStyles = [
-    'margin-bottom-2',
-    'bg-white',
-    'border-2px',
-    'border-transparent',
-    'padding-1',
-    'radius-md',
-    'width-auto',
-    'hover:bg-white',
-    'hover:border-primary',
-    ...styles,
-  ].join(' ');
-
-  const Icon = icon;
-
-  return (
-    <button
-      title={label}
-      className={buttonStyles}
-      onClick={onClick}
-      style={{ cursor: 'pointer' }}
-      type="button"
-    >
-      <Icon
-        aria-hidden="true"
-        className="height-2 margin-right-1 text-primary top-2px usa-icon width-2"
-        focusable="false"
-        role="img"
-      />
-      <span className="font-ui-md text-bold text-primary">{label}</span>
-    </button>
   );
 }
 
@@ -979,6 +941,7 @@ function useQueryParams({
   const [parameterErrors, setParameterErrors] =
     useState<ParameterErrors | null>(null);
   const [parametersLoaded, setParametersLoaded] = useState(false);
+
   // Populate the input fields with URL parameters, if any
   useEffect(() => {
     if (parametersLoaded || !profile || !staticOptions) return;
@@ -1845,6 +1808,7 @@ type HomeContext = {
   filterState: FilterFieldState;
   format: FormatOption;
   formatHandler: (format: Option) => void;
+  maxQuerySize: number;
   profile: Profile;
   queryParams: QueryData;
   queryUrl: string;
@@ -1863,13 +1827,6 @@ type MultiOptionState = ReadonlyArray<Option> | null;
 type MultiSelectFilterProps = SelectFilterProps<
   Extract<FilterField, MultiOptionField>
 >;
-
-type NavButtonProps = {
-  icon: FunctionComponent<SVGProps<SVGSVGElement>>;
-  label: string;
-  onClick?: (ev: MouseEvent) => void;
-  styles?: string[];
-};
 
 type OptionInputHandler = (
   option: SingleOptionState | MultiOptionState,

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+// components
+import { Loading } from 'components/loading';
+import { Summary } from 'components/summary';
+// config
+import { getData, profiles, serverUrl } from 'config';
+// utils
+import { isAbort, useAbort } from 'utils';
+// types
+import type { Profile } from 'config/profiles';
+import type { FetchState } from 'types';
+
+/*
+## Components
+*/
+
+export default NationalDownloads;
+
+export function NationalDownloads() {
+  const { getSignal } = useAbort();
+
+  const [metadata, setMetadata] = useState<FetchState<Metadata>>({
+    status: 'idle',
+    data: null,
+  });
+
+  useEffect(() => {
+    setMetadata({ status: 'pending', data: null });
+    getData<Metadata>(`${serverUrl}/api/nationalDownloads`, getSignal())
+      .then((data) => setMetadata({ status: 'success', data }))
+      .catch((err) => {
+        if (isAbort(err)) return;
+        console.error(err);
+        setMetadata({ status: 'failure', data: null });
+      });
+  }, [getSignal]);
+
+  return (
+    <>
+      <h2>National Downloads</h2>
+      {/* page links? */}
+      <hr />
+      <Summary heading="Description">
+        <></>
+      </Summary>
+      <section className="margin-top-6">
+        <h3 id="attains" className="text-primary">
+          ATTAINS Data
+        </h3>
+        <AttainsData metadata={metadata} />
+      </section>
+    </>
+  );
+}
+
+type AttainsDataProps = {
+  metadata: FetchState<Metadata>;
+};
+
+function AttainsData({ metadata }: AttainsDataProps) {
+  const status = metadata.status;
+
+  if (status === 'failure') return <></>;
+
+  if (status === 'pending') return <Loading />;
+
+  if (status === 'success')
+    return (
+      <table className="margin-x-auto usa-table usa-table--borderless width-full maxw-tablet-lg">
+        <caption>Extracted on {metadata.data.julianDate}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Download link</th>
+            <th scope="col">File size</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(metadata.data.files).map(([profile, fileInfo]) => (
+            <tr key={profile}>
+              <th scope="row">
+                <a href={fileInfo.url}>{profiles[profile as Profile].label}</a>
+              </th>
+              <td>{formatBytes(fileInfo.size)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+
+  return null;
+}
+
+/*
+## Utils
+*/
+
+function formatBytes(bytes: number, decimals = 2) {
+  if (!bytes) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = [
+    'Bytes',
+    'KiB',
+    'MiB',
+    'GiB',
+    'TiB',
+    'PiB',
+    'EiB',
+    'ZiB',
+    'YiB',
+  ];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+/*
+## Types
+*/
+
+type Metadata = {
+  julianDate: number;
+  files: Partial<{
+    [P in Profile]: {
+      url: string;
+      size: number;
+    };
+  }>;
+};

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -96,23 +96,25 @@ function AttainsData({ metadata }: AttainsDataProps) {
           </tr>
         </thead>
         <tbody>
-          {Object.entries(metadata.data.files).map(([profile, fileInfo]) => (
-            <tr key={profile}>
-              <th scope="row">
-                <a href={fileInfo.url}>
-                  {profiles[profile as Profile].label} Profile Data
-                  <Exit
-                    aria-hidden="true"
-                    className="height-2 margin-left-05 text-primary top-05 usa-icon width-2"
-                    focusable="false"
-                    role="img"
-                    title="Exit EPA's Website"
-                  />
-                </a>
-              </th>
-              <td>{formatBytes(fileInfo.size)}</td>
-            </tr>
-          ))}
+          {Object.entries(metadata.data.files)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([profile, fileInfo]) => (
+              <tr key={profile}>
+                <th scope="row">
+                  <a href={fileInfo.url}>
+                    {profiles[profile as Profile].label} Profile Data
+                    <Exit
+                      aria-hidden="true"
+                      className="height-2 margin-left-05 text-primary top-05 usa-icon width-2"
+                      focusable="false"
+                      role="img"
+                      title="Exit EPA's Website"
+                    />
+                  </a>
+                </th>
+                <td>{formatBytes(fileInfo.size)}</td>
+              </tr>
+            ))}
         </tbody>
       </table>
     );

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -47,6 +47,20 @@ type ConcreteOptions = {
 
 export type DomainOptions = ConcreteOptions & Partial<AliasedOptions>;
 
+type EmptyStatus = Exclude<Status, 'success'>;
+
+type FetchEmptyState = {
+  status: EmptyStatus;
+  data: null;
+};
+
+export type FetchState<Type> = FetchEmptyState | FetchSuccessState<Type>;
+
+type FetchSuccessState<Type> = {
+  status: 'success';
+  data: Type;
+};
+
 export type Option = {
   context?: string;
   description?: ReactNode;

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -1,0 +1,28 @@
+import { useEffect, useCallback, useRef } from 'react';
+
+export function useAbort() {
+  const abortController = useRef(new AbortController());
+  const getAbortController = useCallback(() => {
+    if (abortController.current.signal.aborted) {
+      abortController.current = new AbortController();
+    }
+    return abortController.current;
+  }, []);
+
+  const abort = useCallback(() => {
+    getAbortController().abort();
+  }, [getAbortController]);
+
+  useEffect(() => {
+    return function cleanup() {
+      abortController.current.abort();
+    };
+  }, [getAbortController]);
+
+  const getSignal = useCallback(
+    () => getAbortController().signal,
+    [getAbortController],
+  );
+
+  return { abort, getSignal };
+}

--- a/app/client/src/utils/index.ts
+++ b/app/client/src/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './hooks';
+
+export function isAbort(error: unknown) {
+  if (!error || typeof error !== 'object' || !('name' in error)) return false;
+  return (error as Error).name === 'AbortError';
+}

--- a/app/server/app/content/config/parameters.json
+++ b/app/server/app/content/config/parameters.json
@@ -1,4 +1,4 @@
 {
   "debounceMilliseconds": 250,
-  "maxQuerySize": 1_000_000
+  "maxQuerySize": 1000000
 }

--- a/app/server/app/content/config/parameters.json
+++ b/app/server/app/content/config/parameters.json
@@ -1,3 +1,4 @@
 {
-  "debounceMilliseconds": 250
+  "debounceMilliseconds": 250,
+  "maxQuerySize": 1_000_000
 }

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -172,15 +172,7 @@ export default function (app, basePath) {
     Promise.all([filePromises, directoryPromises])
       .then((data) => res.json({ ...data[0], ...data[1] }))
       .catch((error) => {
-        if (typeof error.toJSON === 'function') {
-          log.debug(formatLogMsg(metadataObj, error.toJSON()));
-        }
-
-        const errorStatus = error.response?.status;
-        const errorMethod = error.response?.config?.method?.toUpperCase();
-        const errorUrl = error.response?.config?.url;
-        const message = `S3 Error: ${errorStatus} ${errorMethod} ${errorUrl}`;
-        log.error(formatLogMsg(metadataObj, message));
+        logError(error, metadataObj);
 
         return res
           .status(error?.response?.status || 500)

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import express from 'express';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import path, { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tableConfig } from '../config/tableConfig.js';
@@ -13,10 +13,27 @@ import {
 } from '../utilities/logger.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const isLocal = process.env.NODE_ENV === 'local';
+// const isLocal = process.env.NODE_ENV === 'local';
+const isLocal = false;
 const s3Bucket = process.env.CF_S3_PUB_BUCKET_ID;
 const s3Region = process.env.CF_S3_PUB_REGION;
 const s3BucketUrl = `https://${s3Bucket}.s3-${s3Region}.amazonaws.com`;
+
+function handleError(error, metadataObj) {
+  if (isLocal) {
+    console.error(error);
+  } else {
+    if (typeof error.toJSON === 'function') {
+      log.debug(formatLogMsg(metadataObj, error.toJSON()));
+    }
+
+    const errorStatus = error.response?.status;
+    const errorMethod = error.response?.config?.method?.toUpperCase();
+    const errorUrl = error.response?.config?.url;
+    const message = `S3 Error: ${errorStatus} ${errorMethod} ${errorUrl}`;
+    log.error(formatLogMsg(metadataObj, message));
+  }
+}
 
 // local development: read files directly from disk
 // Cloud.gov: fetch files from the public s3 bucket
@@ -28,6 +45,18 @@ function getFile(filename) {
         url: `${s3BucketUrl}/${filename}`,
         timeout: 10000,
       });
+}
+
+function getFileSize(filename) {
+  return isLocal
+    ? stat(resolve(__dirname, '../', filename), 'utf8').then(
+        (stats) => stats.size,
+      )
+    : axios({
+        method: 'head',
+        url: `${s3BucketUrl}/${filename}`,
+        timeout: 10000,
+      }).then((res) => parseInt(res.headers['content-length']));
 }
 
 // local development: no further processing of strings needed
@@ -233,6 +262,45 @@ export default function (app, basePath) {
         );
         res.status(500).send('Error! ' + error);
       });
+  });
+
+  router.get('/nationalDownloads', async (req, res) => {
+    const metadataObj = populateMetdataObjFromRequest(req);
+
+    const baseDir = 'national-downloads';
+    const resLatest = await getFile(`${baseDir}/latest.json`).catch((err) =>
+      handleError(err, metadataObj),
+    );
+
+    if (!resLatest)
+      return res
+        .status(500)
+        .json({ message: 'Error getting static content from S3 bucket' });
+
+    const latest = parseInt(parseResponse(resLatest).julian);
+
+    const data = {
+      julianDate: latest,
+      files: {},
+    };
+
+    await Promise.all([
+      ...Object.entries(tableConfig).map(async ([profile, config]) => {
+        const basename = config.tableName;
+        const filename = `${baseDir}/${latest}/${basename}.csv.zip`;
+        try {
+          const filesize = await getFileSize(filename);
+          data.files[profile] = {
+            url: `${s3BucketUrl}/${filename}`,
+            size: filesize,
+          };
+        } catch (err) {
+          handleError(err, metadataObj);
+        }
+      }),
+    ]);
+
+    res.status(200).json(data);
   });
 
   app.use(`${basePath}api`, router);


### PR DESCRIPTION
## Related Issues:
* [EQ-164](https://jira.epa.gov/browse/EQ-164)

## Main Changes:
* Added a National Downloads page, which links to the files in the S3 bucket's `national-downloads` folder.
  * This page is a top-level route, so it is structured such that later projects could use the same page. The ATTAINS national downloads are listed in the **ATTAINS Data** section.
* Added a message to the download modal on the main query page that links users to the National Downloads page if queries are too large. If there are no filters on a profile query, the message will show immediately, otherwise if the count exceeds a configured number then the message will show.

## Steps To Test:
1. Create the directory `app/server/app/national-downloads`, then copy one or several of the latest gzipped national download archives (_table\_name_.csv.gz) into the folder.
2. Start the application, then navigate to http://localhost:3000/national-downloads.
3. Confirm that the archive is listed in the **ATTAINS Data** section, and take note of the file size.
4. In `app/server/app/routes/api.js`, replace line 16 with `const isLocal = false`, then reload the National Downloads page.
5. Confirm that all profile archives are listed, and that the previously noted file size matches the files size of the corresponding profile currently in the list.
6. Navigate to http://localhost:3000/attains/tmdl.
7. Without selecting any filters, click **Download**, and confirm that the download modal shows a "max size exceeded" message, with a link to the ATTAINS section on the National Downloads page.
8. Create a query that exceeds the number configured by the `maxQuerySize` variable. This is currently set as 1,000,000, so it may help to dial the number down a bit.
9. Confirm that the "max size exceeded" message shows after calculating the query's total result count.