### PR TITLE
Feature/225 reset select filters

### DIFF
--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -732,10 +732,9 @@ function SelectFilter<
       onMenuClose={() => {
         abort();
         setLoading(false);
+        setOptions(null);
       }}
-      onMenuOpen={() => {
-        if (!options) loadOptions();
-      }}
+      onMenuOpen={loadOptions}
       options={options ?? undefined}
       placeholder={`Select ${getArticle(
         filterLabel.split(' ')[0],


### PR DESCRIPTION
## Related Issues:
* [EQ-225](https://jira.epa.gov/browse/EQ-225)

## Main Changes:
* Reset the options in select inputs when closing their drop-downs.
  * I'd considered that it might be handy to keep the last-searched options,, but I see how this could be confusing, especially if less than 20 options are shown.

## Steps To Test:
1. Navigate to localhost:3000/attains/assessmentUnits.
2. Open the **Assessment Unit ID** dropdown, and note the visible options.
3. In the **Assessment Unit ID** filter input, type in "CAB", and wait for the options to filter.
4. Only options that start with "CAB" should be visible.
5. Close the drowdown.
6. Re-open the dropdown.
7. The initial options should be visible, and no options that start with "CAB" should be visible.