### PR TITLE
Feature/226 national downloads timestamps

### DIFF
--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -87,20 +87,21 @@ function AttainsData({ metadata }: AttainsDataProps) {
 
   if (status === 'success')
     return (
-      <table className="margin-x-auto usa-table usa-table--borderless width-full maxw-tablet-lg">
-        <caption>Extracted on {formatDate(metadata.data.epochSeconds)}</caption>
+      <table className="margin-x-auto usa-table usa-table--borderless usa-table--stacked width-full maxw-tablet-lg">
         <thead>
           <tr>
             <th scope="col">Download link</th>
+            <th scope="col">Time last refreshed</th>
+            <th scope="col">Number of rows</th>
             <th scope="col">File size</th>
           </tr>
         </thead>
         <tbody>
-          {Object.entries(metadata.data.files)
+          {Object.entries(metadata.data)
             .sort((a, b) => a[0].localeCompare(b[0]))
             .map(([profile, fileInfo]) => (
               <tr key={profile}>
-                <th scope="row">
+                <th scope="row" data-label="Download link">
                   <a href={fileInfo.url}>
                     {profiles[profile as Profile].label} Profile Data
                     <Exit
@@ -112,7 +113,13 @@ function AttainsData({ metadata }: AttainsDataProps) {
                     />
                   </a>
                 </th>
-                <td>{formatBytes(fileInfo.size)}</td>
+                <td data-label="Time last refreshed">
+                  {formatDate(fileInfo.timestamp)}
+                </td>
+                <td data-label="Number of rows">
+                  {fileInfo.numRows.toLocaleString()}
+                </td>
+                <td data-label="File size">{formatBytes(fileInfo.size)}</td>
               </tr>
             ))}
         </tbody>
@@ -135,24 +142,31 @@ function formatBytes(bytes: number, decimals = 2) {
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+  return `${parseFloat(
+    (bytes / Math.pow(k, i)).toFixed(dm),
+  ).toLocaleString()} ${sizes[i]}`;
 }
 
-function formatDate(seconds: number) {
-  const date = new Date(seconds * 1000);
-  return date.toDateString();
+function formatDate(isoTimestamp: string) {
+  const datestring = new Date(isoTimestamp).toLocaleString();
+  const [date, time] = datestring.split(',');
+  return (
+    <div className="display-flex flex-wrap">
+      <span className="margin-right-05">{date},</span>
+      <span>{time}</span>
+    </div>
+  );
 }
 
 /*
 ## Types
 */
 
-type Metadata = {
-  epochSeconds: number;
-  files: Partial<{
-    [P in Profile]: {
-      url: string;
-      size: number;
-    };
-  }>;
-};
+type Metadata = Partial<{
+  [P in Profile]: {
+    url: string;
+    size: number;
+    numRows: number;
+    timestamp: string;
+  };
+}>;

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -87,7 +87,7 @@ function AttainsData({ metadata }: AttainsDataProps) {
 
   if (status === 'success')
     return (
-      <table className="margin-x-auto usa-table usa-table--borderless usa-table--stacked width-full maxw-tablet-lg">
+      <table className="margin-x-auto usa-table usa-table--stacked width-full">
         <thead>
           <tr>
             <th scope="col">Download link</th>

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -13,8 +13,7 @@ import {
 } from '../utilities/logger.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// const isLocal = process.env.NODE_ENV === 'local';
-const isLocal = false;
+const isLocal = process.env.NODE_ENV === 'local';
 const s3Bucket = process.env.CF_S3_PUB_BUCKET_ID;
 const s3Region = process.env.CF_S3_PUB_REGION;
 const s3BucketUrl = `https://${s3Bucket}.s3-${s3Region}.amazonaws.com`;

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -84,13 +84,14 @@ async function cacheProfileStats(pool, schemaName, profileStats) {
     await client.query('BEGIN');
     for (const profile of profileStats) {
       await client.query(
-        'INSERT INTO logging.mv_profile_stats(profile_name, schema_name, num_rows, last_refresh_end_time, creation_date)' +
-          ' VALUES ($1, $2, $3, $4, current_timestamp)',
+        'INSERT INTO logging.mv_profile_stats(profile_name, schema_name, num_rows, last_refresh_end_time, last_refresh_elapsed, creation_date)' +
+          ' VALUES ($1, $2, $3, $4, $5, current_timestamp)',
         [
           profile['name'].replace('attains_app.profile_', ''),
           schemaName,
           profile['num_rows'],
           profile['last_refresh_end_time'],
+          profile['last_refresh_elapsed'],
         ],
       );
     }
@@ -163,6 +164,7 @@ export async function checkLogTables() {
           schema_name VARCHAR(20) NOT NULL,
           num_rows INTEGER NOT NULL,
           last_refresh_end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+          last_refresh_elapsed VARCHAR(20) NOT NULL,
           creation_date TIMESTAMP WITHOUT TIME ZONE NOT NULL,
           PRIMARY KEY (profile_name, schema_name)
         )`,

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -78,6 +78,25 @@ export async function endConnPool(pool) {
   log.info('EqPool connection pool ended');
 }
 
+async function cacheProfileStats(
+  pool,
+  profileName,
+  schemaName,
+  numRows,
+  refreshTime,
+) {
+  try {
+    await pool.query(
+      'INSERT INTO logging.mv_profile_stats(profile_name, schema_name, num_rows, last_refresh_end_time, creation_date)' +
+        ' VALUES ($1, $2, $3, $4, current_timestamp)',
+      [profileName, schemaName, numRows, refreshTime],
+    );
+    log.info(`Profile stats for ${profileName} cached`);
+  } catch (err) {
+    log.warn(`Failed to cache stats for profile ${profileName}: ${err}`);
+  }
+}
+
 export async function checkLogTables() {
   const client = await connectClient(eqConfig);
 
@@ -126,6 +145,19 @@ export async function checkLogTables() {
           database VARCHAR(20),
           glossary VARCHAR(20),
           domain_values VARCHAR(20)
+        )`,
+    );
+
+    // create mv_profile_stats table
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS logging.mv_profile_stats
+        (
+          profile_name VARCHAR(40) NOT NULL,
+          schema_name VARCHAR(20) NOT NULL,
+          num_rows INTEGER NOT NULL,
+          last_refresh_end_time TIMESTAMP WITH TIME ZONE NOT NULL,
+          creation_date TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+          PRIMARY KEY (profile_name, schema_name)
         )`,
     );
 
@@ -473,10 +505,12 @@ export async function runLoad(pool, s3Config, s3Julian) {
     });
     await Promise.all(loadTasks);
 
+    const profileStats = await getProfileStats(pool, s3Config, schemaName);
+
     // Verify the etl was successfull and the data matches what we expect.
     // We skip this when running locally, since the row counts will never match.
     if (!environment.isLocal) {
-      await certifyEtlComplete(pool, s3Config, schemaId, schemaName);
+      await certifyEtlComplete(pool, profileStats, schemaId, schemaName);
     }
 
     await transferSchema(pool, schemaName, schemaId);
@@ -490,15 +524,7 @@ export async function runLoad(pool, s3Config, s3Julian) {
   }
 }
 
-// Verify the data pulled in from the ETL matches the materialized views.
-export async function certifyEtlComplete(
-  pool,
-  s3Config,
-  logId,
-  schemaName,
-  retryCount = 0,
-) {
-  // get profile stats
+async function getProfileStats(pool, s3Config, schemaName, retryCount = 0) {
   const url = `${s3Config.services.materializedViews}/profile_stats`;
   const res = await axios.get(url, {
     headers: { 'API-key': process.env.MV_API_KEY },
@@ -514,15 +540,30 @@ export async function certifyEtlComplete(
     log.info('Non-200 response returned from profile_stats service, retrying');
     if (retryCount < s3Config.config.retryLimit) {
       await setTimeout(s3Config.config.retryIntervalSeconds * 1000);
-      return await certifyEtlComplete(pool, s3Config, retryCount + 1);
+      return await getProfileStats(pool, s3Config, schemaName, retryCount + 1);
     } else {
       throw new Error('Retry count exceeded');
     }
   }
 
+  for (const profile of res.data.details) {
+    cacheProfileStats(
+      pool,
+      profile.name.replace('attains_app.profile_', ''),
+      schemaName,
+      profile.num_rows,
+      profile.last_refresh_end_time,
+    );
+  }
+
+  return res.data.details;
+}
+
+// Verify the data pulled in from the ETL matches the materialized views.
+async function certifyEtlComplete(pool, profileStats, logId, schemaName) {
   // loop through and make sure the tables exist and the counts match
   let issuesMessage = '';
-  for (const profile of res.data.details) {
+  for (const profile of profileStats) {
     // check date
     if (profile.last_refresh_end_time <= profile.last_refresh_date) {
       issuesMessage += `${profile.name} issue: last_refresh_end_time (${profile.last_refresh_end_time}) is not after last_refresh_date (${profile.last_refresh_date}).\n`;


### PR DESCRIPTION
## Related Issues:
* [EQ-226](https://jira.epa.gov/browse/EQ-226)

## Main Changes:
* Added columns for the "last refreshed date" and "number of row" to the National Downloads table.
* Added a table to the ETL "logging" table that caches the current profile stats at the time of the ETL job.
* Updated the table styles on the National Downloads page to accommodate the added rows.

## Steps To Test:
1. Run the ETL while pointed at a local database. This will still cache the current profile stats provided by the `attains_eq/profile_stats` endpoint, but it will skip the check that uses the stats to certify ETL completion.
2. Run the client application, then navigate to localhost:3000/national-downloads. It may help to first replace line 16 of `app/server/app/routes/api.js` with `const isLocal = false`.
3. Confirm that the refresh date and the number of rows are displayed appropriately for each profile.
4. Resize the window and confirm that the table is adequately responsive.