### PR TITLE
Feature/209 select performance

### DIFF
--- a/app/server/app/config/tableConfig.js
+++ b/app/server/app/config/tableConfig.js
@@ -68,6 +68,7 @@ export const tableConfig = {
         columns: [
           { name: 'actionid' },
           { name: 'actionname' },
+          { name: 'actiontype' },
           { name: 'organizationid' },
           { name: 'organizationname' },
           { name: 'organizationtype' },

--- a/app/server/app/config/tableConfig.js
+++ b/app/server/app/config/tableConfig.js
@@ -9,8 +9,14 @@ export const tableConfig = {
       { name: 'actionid', alias: 'actionId' },
       { name: 'actionname', alias: 'actionName' },
       { name: 'actiontype', alias: 'actionType', skipIndex: true },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       {
         name: 'completiondate',
         alias: 'completionDate',
@@ -27,7 +33,10 @@ export const tableConfig = {
         skipIndex: true,
       },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'parameter', alias: 'parameter' },
       { name: 'region', alias: 'region' },
@@ -41,6 +50,32 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'actions_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'actions_actions',
+        columns: [
+          { name: 'actionid' },
+          { name: 'actionname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+    ],
   },
   assessments: {
     tableName: 'assessments',
@@ -51,7 +86,10 @@ export const tableConfig = {
         name: 'alternatelistingidentifier',
         alias: 'alternateListingIdentifier',
       },
-      { name: 'assessmentbasis', alias: 'assessmentBasis' },
+      {
+        name: 'assessmentbasis',
+        alias: 'assessmentBasis',
+      },
       {
         name: 'assessmentdate',
         alias: 'assessmentDate',
@@ -60,14 +98,29 @@ export const tableConfig = {
         type: 'timestamptz',
         indexOrder: 'desc',
       },
-      { name: 'assessmentmethods', alias: 'assessmentMethods' },
+      {
+        name: 'assessmentmethods',
+        alias: 'assessmentMethods',
+      },
       { name: 'assessmenttypes', alias: 'assessmentTypes' },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       { name: 'associatedactionagency', alias: 'associatedActionAgency' },
-      { name: 'associatedactionid', alias: 'associatedActionId' },
-      { name: 'associatedactionname', alias: 'associatedActionName' },
+      {
+        name: 'associatedactionid',
+        alias: 'associatedActionId',
+      },
+      {
+        name: 'associatedactionname',
+        alias: 'associatedActionName',
+      },
       { name: 'associatedactionstatus', alias: 'associatedActionStatus' },
       { name: 'associatedactiontype', alias: 'associatedActionType' },
       {
@@ -141,10 +194,16 @@ export const tableConfig = {
         indexOrder: 'desc',
       },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'overallstatus', alias: 'overallStatus' },
-      { name: 'parameterattainment', alias: 'parameterAttainment' },
+      {
+        name: 'parameterattainment',
+        alias: 'parameterAttainment',
+      },
       { name: 'parametergroup', alias: 'parameterGroup' },
       {
         name: 'parameterircategory',
@@ -207,14 +266,91 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessments_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessments_alternatelistingidentifier',
+        columns: [{ name: 'alternatelistingidentifier' }],
+      },
+      {
+        name: 'assessments_assessmentbasis',
+        columns: [{ name: 'assessmentbasis' }],
+      },
+      {
+        name: 'assessments_assessmentmethods',
+        columns: [{ name: 'assessmentmethods' }],
+      },
+      {
+        name: 'assessments_associatedaction',
+        columns: [
+          { name: 'associatedactionid' },
+          { name: 'associatedactionname' },
+          { name: 'associatedactionstatus' },
+          { name: 'associatedactiontype' },
+        ],
+      },
+      {
+        name: 'assessments_epaircategory',
+        columns: [{ name: 'epaircategory' }],
+      },
+      {
+        name: 'assessments_overallstatus',
+        columns: [{ name: 'overallstatus' }],
+      },
+      {
+        name: 'assessments_parameterattainment',
+        columns: [{ name: 'parameterattainment' }],
+      },
+      {
+        name: 'assessments_parameterircategory',
+        columns: [{ name: 'parameterircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_parameterstateircategory',
+        columns: [{ name: 'parameterstateircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_usegroup',
+        columns: [{ name: 'usegroup' }],
+      },
+      {
+        name: 'assessments_useircategory',
+        columns: [{ name: 'useircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_usestateircategory',
+        columns: [{ name: 'usestateircategory', type: 'numeric' }],
+      },
+    ],
   },
   assessmentUnits: {
     tableName: 'assessment_units',
     idColumn: 'objectid',
     columns: [
       { name: 'objectid', alias: 'objectid', skipIndex: true },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       {
         name: 'cycleid',
@@ -227,10 +363,13 @@ export const tableConfig = {
         skipIndex: true,
       },
       { name: 'locationtext', alias: 'locationText' },
-      { name: 'locationtypecode', alias: 'locationTypeCode', skipIndex: true },
+      { name: 'locationtypecode', alias: 'locationTypeCode' },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
-      { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
+      { name: 'organizationtype', alias: 'organizationType' },
       { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
@@ -252,14 +391,41 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessmentunits_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessmentunits_locationtext',
+        columns: [{ name: 'locationtext' }],
+      },
+      {
+        name: 'assessmentunits_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+    ],
   },
   assessmentUnitsMonitoringLocations: {
     tableName: 'assessment_units_monitoring_locations',
     idColumn: 'objectid',
     columns: [
       { name: 'objectid', alias: 'objectId', skipIndex: true },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       {
         name: 'cycleid',
@@ -276,10 +442,19 @@ export const tableConfig = {
         alias: 'monitoringLocationDataLink',
         skipIndex: true,
       },
-      { name: 'monitoringlocationid', alias: 'monitoringLocationId' },
-      { name: 'monitoringlocationorgid', alias: 'monitoringLocationOrgId' },
+      {
+        name: 'monitoringlocationid',
+        alias: 'monitoringLocationId',
+      },
+      {
+        name: 'monitoringlocationorgid',
+        alias: 'monitoringLocationOrgId',
+      },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'region', alias: 'region' },
       {
@@ -302,14 +477,44 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessmentunitsmonitoringlocations_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessmentunitsmonitoringlocations_locationtext',
+        columns: [
+          { name: 'monitoringlocationid' },
+          { name: 'monitoringlocationorgid' },
+        ],
+      },
+      {
+        name: 'assessmentunitsmonitoringlocations_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+    ],
   },
   catchmentCorrespondence: {
     tableName: 'catchment_correspondence',
     idColumn: 'objectid',
     columns: [
       { name: 'objectid', alias: 'objectId', skipIndex: true },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       {
         name: 'catchmentnhdplusid',
         alias: 'catchmentNhdPlusId',
@@ -321,7 +526,10 @@ export const tableConfig = {
         type: 'numeric',
       },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'region', alias: 'region' },
       {
@@ -333,14 +541,41 @@ export const tableConfig = {
       },
       { name: 'state', alias: 'state' },
     ],
+    materializedViews: [
+      {
+        name: 'catchmentcorrespondence_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'catchmentcorrespondence_catchmentnhdplusid',
+        columns: [{ name: 'catchmentnhdplusid', skipIndex: true }],
+      },
+      {
+        name: 'catchmentcorrespondence_reportingcycle',
+        columns: [{ name: 'reportingcycle', skipIndex: true }],
+      },
+    ],
   },
   sources: {
     tableName: 'sources',
     idColumn: 'objectid',
     columns: [
       { name: 'objectid', alias: 'objectId', skipIndex: true },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       { name: 'causename', alias: 'causeName' },
       { name: 'confirmed', alias: 'confirmed' },
       {
@@ -355,7 +590,10 @@ export const tableConfig = {
         skipIndex: true,
       },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'overallstatus', alias: 'overallStatus' },
       { name: 'parametergroup', alias: 'parameterGroup' },
@@ -379,6 +617,35 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'sources_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'sources_causename',
+        columns: [{ name: 'causename' }],
+      },
+      {
+        name: 'sources_epaircategory',
+        columns: [{ name: 'epaircategory' }],
+      },
+      {
+        name: 'sources_overallstatus',
+        columns: [{ name: 'overallstatus' }],
+      },
+      {
+        name: 'sources_reportingcycle',
+        columns: [{ name: 'reportingcycle', skipIndex: true }],
+      },
+    ],
   },
   tmdl: {
     tableName: 'tmdl',
@@ -388,9 +655,18 @@ export const tableConfig = {
       { name: 'actionagency', alias: 'actionAgency' },
       { name: 'actionid', alias: 'actionId' },
       { name: 'actionname', alias: 'actionName' },
-      { name: 'addressedparameter', alias: 'addressedParameter' },
-      { name: 'assessmentunitid', alias: 'assessmentUnitId' },
-      { name: 'assessmentunitname', alias: 'assessmentUnitName' },
+      {
+        name: 'addressedparameter',
+        alias: 'addressedParameter',
+      },
+      {
+        name: 'assessmentunitid',
+        alias: 'assessmentUnitId',
+      },
+      {
+        name: 'assessmentunitname',
+        alias: 'assessmentUnitName',
+      },
       {
         name: 'completiondate',
         alias: 'completionDate',
@@ -399,7 +675,10 @@ export const tableConfig = {
         type: 'timestamptz',
         indexOrder: 'desc',
       },
-      { name: 'explicitmarginofsafety', alias: 'explicitMarginOfSafety' },
+      {
+        name: 'explicitmarginofsafety',
+        alias: 'explicitMarginOfSafety',
+      },
       {
         name: 'fiscalyearestablished',
         alias: 'fiscalYearEstablished',
@@ -407,7 +686,10 @@ export const tableConfig = {
         highParam: 'fiscalYearEstablishedHi',
         indexOrder: 'desc',
       },
-      { name: 'implicitmarginofsafety', alias: 'implicitMarginOfSafety' },
+      {
+        name: 'implicitmarginofsafety',
+        alias: 'implicitMarginOfSafety',
+      },
       { name: 'includeinmeasure', alias: 'includeInMeasure' },
       { name: 'inindiancountry', alias: 'inIndianCountry' },
       {
@@ -426,11 +708,20 @@ export const tableConfig = {
         alias: 'locationDescription',
         skipIndex: true,
       },
-      { name: 'npdesidentifier', alias: 'npdesIdentifier' },
+      {
+        name: 'npdesidentifier',
+        alias: 'npdesIdentifier',
+      },
       { name: 'organizationid', alias: 'organizationId' },
-      { name: 'organizationname', alias: 'organizationName' },
+      {
+        name: 'organizationname',
+        alias: 'organizationName',
+      },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'otheridentifier', alias: 'otherIdentifier' },
+      {
+        name: 'otheridentifier',
+        alias: 'otherIdentifier',
+      },
       { name: 'pollutant', alias: 'pollutant' },
       { name: 'region', alias: 'region' },
       { name: 'sourcetype', alias: 'sourceType' },
@@ -457,6 +748,47 @@ export const tableConfig = {
       },
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
+    ],
+    materializedViews: [
+      {
+        name: 'tmdl_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'tmdl_actions',
+        columns: [
+          { name: 'actionid' },
+          { name: 'actionname' },
+          { name: 'actionagency' },
+        ],
+      },
+      {
+        name: 'tmdl_addressedparameter',
+        columns: [{ name: 'addressedparameter' }],
+      },
+      {
+        name: 'tmdl_explicitmarginofsafety',
+        columns: [{ name: 'explicitmarginofsafety' }],
+      },
+      {
+        name: 'tmdl_implicitmarginofsafety',
+        columns: [{ name: 'implicitmarginofsafety' }],
+      },
+      {
+        name: 'tmdl_npdesidentifier',
+        columns: [{ name: 'npdesidentifier' }],
+      },
+      {
+        name: 'tmdl_otheridentifier',
+        columns: [{ name: 'otheridentifier' }],
+      },
     ],
   },
 };

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -79,10 +79,32 @@ async function queryColumnValues(profile, column, params, schema) {
     else parsedParams.filters[name] = value;
   });
 
+  // get columns for where clause
+  const columnsForFilter = [];
+  profile.columns.forEach((col) => {
+    if (parsedParams.filters.hasOwnProperty(col.alias)) {
+      columnsForFilter.push(col.name);
+    }
+  });
+
+  // search through tableconfig.materializedViews to see if the column
+  // we need is in here
+  const materializedView = profile.materializedViews.find((mv) => {
+    let hasAllColumns = mv.columns.find((mvCol) => mvCol.name === column.name);
+    columnsForFilter.forEach((col) => {
+      const column = mv.columns.find((mvCol) => mvCol.name === col);
+      if (!column) hasAllColumns = false;
+    });
+
+    if (hasAllColumns) return mv;
+  });
+
+  // query table directly if a suitable materialized view was not found
   const query = knex
     .withSchema(schema)
-    .from(profile.tableName)
+    .from(materializedView ? materializedView.name : profile.tableName)
     .column(column.name)
+    .whereNotNull(column.name)
     .distinctOn(column.name)
     .orderBy(column.name, parsedParams.direction ?? 'asc')
     .select();

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -90,13 +90,10 @@ async function queryColumnValues(profile, column, params, schema) {
   // search through tableconfig.materializedViews to see if the column
   // we need is in here
   const materializedView = profile.materializedViews.find((mv) => {
-    let hasAllColumns = mv.columns.find((mvCol) => mvCol.name === column.name);
-    columnsForFilter.forEach((col) => {
-      const column = mv.columns.find((mvCol) => mvCol.name === col);
-      if (!column) hasAllColumns = false;
-    });
-
-    if (hasAllColumns) return mv;
+    for (const col of columnsForFilter.concat(column.name)) {
+      if (!mv.columns.find((mvCol) => mvCol.name === col)) return;
+    }
+    return mv;
   });
 
   // query table directly if a suitable materialized view was not found

--- a/etl/app/config/tableConfig.js
+++ b/etl/app/config/tableConfig.js
@@ -68,6 +68,7 @@ export const tableConfig = {
         columns: [
           { name: 'actionid' },
           { name: 'actionname' },
+          { name: 'actiontype' },
           { name: 'organizationid' },
           { name: 'organizationname' },
           { name: 'organizationtype' },

--- a/etl/app/config/tableConfig.js
+++ b/etl/app/config/tableConfig.js
@@ -6,18 +6,16 @@ export const tableConfig = {
     columns: [
       { name: 'objectid', alias: 'objectId', skipIndex: true },
       { name: 'actionagency', alias: 'actionAgency' },
-      { name: 'actionid', alias: 'actionId', includeGinIndex: true },
-      { name: 'actionname', alias: 'actionName', includeGinIndex: true },
+      { name: 'actionid', alias: 'actionId' },
+      { name: 'actionname', alias: 'actionName' },
       { name: 'actiontype', alias: 'actionType', skipIndex: true },
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       {
         name: 'completiondate',
@@ -38,11 +36,10 @@ export const tableConfig = {
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       { name: 'parameter', alias: 'parameter' },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       { name: 'state', alias: 'state' },
       {
         name: 'watersize',
@@ -53,6 +50,32 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'actions_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'actions_actions',
+        columns: [
+          { name: 'actionid' },
+          { name: 'actionname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+    ],
   },
   assessments: {
     tableName: 'assessments',
@@ -62,12 +85,10 @@ export const tableConfig = {
       {
         name: 'alternatelistingidentifier',
         alias: 'alternateListingIdentifier',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentbasis',
         alias: 'assessmentBasis',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentdate',
@@ -80,30 +101,25 @@ export const tableConfig = {
       {
         name: 'assessmentmethods',
         alias: 'assessmentMethods',
-        includeGinIndex: true,
       },
       { name: 'assessmenttypes', alias: 'assessmentTypes' },
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       { name: 'associatedactionagency', alias: 'associatedActionAgency' },
       {
         name: 'associatedactionid',
         alias: 'associatedActionId',
-        includeGinIndex: true,
       },
       {
         name: 'associatedactionname',
         alias: 'associatedActionName',
-        includeGinIndex: true,
       },
       { name: 'associatedactionstatus', alias: 'associatedActionStatus' },
       { name: 'associatedactiontype', alias: 'associatedActionType' },
@@ -155,7 +171,7 @@ export const tableConfig = {
       },
       { name: 'delisted', alias: 'delisted' },
       { name: 'delistedreason', alias: 'delistedReason' },
-      { name: 'epaircategory', alias: 'epaIrCategory', includeGinIndex: true },
+      { name: 'epaircategory', alias: 'epaIrCategory' },
       {
         name: 'locationdescription',
         alias: 'locationDescription',
@@ -181,14 +197,12 @@ export const tableConfig = {
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'overallstatus', alias: 'overallStatus', includeGinIndex: true },
+      { name: 'overallstatus', alias: 'overallStatus' },
       {
         name: 'parameterattainment',
         alias: 'parameterAttainment',
-        includeGinIndex: true,
       },
       { name: 'parametergroup', alias: 'parameterGroup' },
       {
@@ -204,7 +218,7 @@ export const tableConfig = {
       },
       { name: 'parameterstatus', alias: 'parameterStatus' },
       { name: 'pollutantindicator', alias: 'pollutantIndicator' },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
         alias: 'reportingCycle',
@@ -233,7 +247,7 @@ export const tableConfig = {
       { name: 'state', alias: 'state' },
       { name: 'stateircategory', alias: 'stateIrCategory' },
       { name: 'useclassname', alias: 'useClassName' },
-      { name: 'usegroup', alias: 'useGroup', includeGinIndex: true },
+      { name: 'usegroup', alias: 'useGroup' },
       { name: 'useircategory', alias: 'useIrCategory', type: 'numeric' },
       { name: 'usename', alias: 'useName' },
       {
@@ -252,6 +266,77 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessments_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'organizationtype' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessments_alternatelistingidentifier',
+        columns: [{ name: 'alternatelistingidentifier' }],
+      },
+      {
+        name: 'assessments_assessmentbasis',
+        columns: [{ name: 'assessmentbasis' }],
+      },
+      {
+        name: 'assessments_assessmentmethods',
+        columns: [{ name: 'assessmentmethods' }],
+      },
+      {
+        name: 'assessments_associatedaction',
+        columns: [
+          { name: 'associatedactionid' },
+          { name: 'associatedactionname' },
+          { name: 'associatedactionstatus' },
+          { name: 'associatedactiontype' },
+        ],
+      },
+      {
+        name: 'assessments_epaircategory',
+        columns: [{ name: 'epaircategory' }],
+      },
+      {
+        name: 'assessments_overallstatus',
+        columns: [{ name: 'overallstatus' }],
+      },
+      {
+        name: 'assessments_parameterattainment',
+        columns: [{ name: 'parameterattainment' }],
+      },
+      {
+        name: 'assessments_parameterircategory',
+        columns: [{ name: 'parameterircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_parameterstateircategory',
+        columns: [{ name: 'parameterstateircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_usegroup',
+        columns: [{ name: 'usegroup' }],
+      },
+      {
+        name: 'assessments_useircategory',
+        columns: [{ name: 'useircategory', type: 'numeric' }],
+      },
+      {
+        name: 'assessments_usestateircategory',
+        columns: [{ name: 'usestateircategory', type: 'numeric' }],
+      },
+    ],
   },
   assessmentUnits: {
     tableName: 'assessment_units',
@@ -261,12 +346,10 @@ export const tableConfig = {
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       {
@@ -279,16 +362,15 @@ export const tableConfig = {
         alias: 'locationDescription',
         skipIndex: true,
       },
-      { name: 'locationtext', alias: 'locationText', includeGinIndex: true },
-      { name: 'locationtypecode', alias: 'locationTypeCode', skipIndex: true },
+      { name: 'locationtext', alias: 'locationText' },
+      { name: 'locationtypecode', alias: 'locationTypeCode' },
       { name: 'organizationid', alias: 'organizationId' },
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
-      { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'organizationtype', alias: 'organizationType' },
+      { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
         alias: 'reportingCycle',
@@ -309,6 +391,27 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessmentunits_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessmentunits_locationtext',
+        columns: [{ name: 'locationtext' }],
+      },
+      {
+        name: 'assessmentunits_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+    ],
   },
   assessmentUnitsMonitoringLocations: {
     tableName: 'assessment_units_monitoring_locations',
@@ -318,12 +421,10 @@ export const tableConfig = {
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       { name: 'assessmentunitstatus', alias: 'assessmentUnitStatus' },
       {
@@ -344,21 +445,18 @@ export const tableConfig = {
       {
         name: 'monitoringlocationid',
         alias: 'monitoringLocationId',
-        includeGinIndex: true,
       },
       {
         name: 'monitoringlocationorgid',
         alias: 'monitoringLocationOrgId',
-        includeGinIndex: true,
       },
       { name: 'organizationid', alias: 'organizationId' },
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
         alias: 'reportingCycle',
@@ -379,6 +477,30 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'assessmentunitsmonitoringlocations_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'assessmentunitsmonitoringlocations_locationtext',
+        columns: [
+          { name: 'monitoringlocationid' },
+          { name: 'monitoringlocationorgid' },
+        ],
+      },
+      {
+        name: 'assessmentunitsmonitoringlocations_reportingcycle',
+        columns: [{ name: 'reportingcycle', type: 'numeric' }],
+      },
+    ],
   },
   catchmentCorrespondence: {
     tableName: 'catchment_correspondence',
@@ -388,12 +510,10 @@ export const tableConfig = {
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       {
         name: 'catchmentnhdplusid',
@@ -409,10 +529,9 @@ export const tableConfig = {
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
         alias: 'reportingCycle',
@@ -421,6 +540,27 @@ export const tableConfig = {
         indexOrder: 'desc',
       },
       { name: 'state', alias: 'state' },
+    ],
+    materializedViews: [
+      {
+        name: 'catchmentcorrespondence_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'catchmentcorrespondence_catchmentnhdplusid',
+        columns: [{ name: 'catchmentnhdplusid', skipIndex: true }],
+      },
+      {
+        name: 'catchmentcorrespondence_reportingcycle',
+        columns: [{ name: 'reportingcycle', skipIndex: true }],
+      },
     ],
   },
   sources: {
@@ -431,21 +571,19 @@ export const tableConfig = {
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
-      { name: 'causename', alias: 'causeName', includeGinIndex: true },
+      { name: 'causename', alias: 'causeName' },
       { name: 'confirmed', alias: 'confirmed' },
       {
         name: 'cycleid',
         alias: 'cycleId',
         type: 'numeric',
       },
-      { name: 'epaircategory', alias: 'epaIrCategory', includeGinIndex: true },
+      { name: 'epaircategory', alias: 'epaIrCategory' },
       {
         name: 'locationdescription',
         alias: 'locationDescription',
@@ -455,12 +593,11 @@ export const tableConfig = {
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
-      { name: 'overallstatus', alias: 'overallStatus', includeGinIndex: true },
+      { name: 'overallstatus', alias: 'overallStatus' },
       { name: 'parametergroup', alias: 'parameterGroup' },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       {
         name: 'reportingcycle',
         alias: 'reportingCycle',
@@ -480,6 +617,35 @@ export const tableConfig = {
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
     ],
+    materializedViews: [
+      {
+        name: 'sources_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'sources_causename',
+        columns: [{ name: 'causename' }],
+      },
+      {
+        name: 'sources_epaircategory',
+        columns: [{ name: 'epaircategory' }],
+      },
+      {
+        name: 'sources_overallstatus',
+        columns: [{ name: 'overallstatus' }],
+      },
+      {
+        name: 'sources_reportingcycle',
+        columns: [{ name: 'reportingcycle', skipIndex: true }],
+      },
+    ],
   },
   tmdl: {
     tableName: 'tmdl',
@@ -487,22 +653,19 @@ export const tableConfig = {
     columns: [
       { name: 'objectid', alias: 'objectId', skipIndex: true },
       { name: 'actionagency', alias: 'actionAgency' },
-      { name: 'actionid', alias: 'actionId', includeGinIndex: true },
-      { name: 'actionname', alias: 'actionName', includeGinIndex: true },
+      { name: 'actionid', alias: 'actionId' },
+      { name: 'actionname', alias: 'actionName' },
       {
         name: 'addressedparameter',
         alias: 'addressedParameter',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitid',
         alias: 'assessmentUnitId',
-        includeGinIndex: true,
       },
       {
         name: 'assessmentunitname',
         alias: 'assessmentUnitName',
-        includeGinIndex: true,
       },
       {
         name: 'completiondate',
@@ -515,7 +678,6 @@ export const tableConfig = {
       {
         name: 'explicitmarginofsafety',
         alias: 'explicitMarginOfSafety',
-        includeGinIndex: true,
       },
       {
         name: 'fiscalyearestablished',
@@ -527,7 +689,6 @@ export const tableConfig = {
       {
         name: 'implicitmarginofsafety',
         alias: 'implicitMarginOfSafety',
-        includeGinIndex: true,
       },
       { name: 'includeinmeasure', alias: 'includeInMeasure' },
       { name: 'inindiancountry', alias: 'inIndianCountry' },
@@ -550,22 +711,19 @@ export const tableConfig = {
       {
         name: 'npdesidentifier',
         alias: 'npdesIdentifier',
-        includeGinIndex: true,
       },
       { name: 'organizationid', alias: 'organizationId' },
       {
         name: 'organizationname',
         alias: 'organizationName',
-        includeGinIndex: true,
       },
       { name: 'organizationtype', alias: 'organizationType', skipIndex: true },
       {
         name: 'otheridentifier',
         alias: 'otherIdentifier',
-        includeGinIndex: true,
       },
       { name: 'pollutant', alias: 'pollutant' },
-      { name: 'region', alias: 'region', includeGinIndex: true },
+      { name: 'region', alias: 'region' },
       { name: 'sourcetype', alias: 'sourceType' },
       { name: 'state', alias: 'state' },
       {
@@ -590,6 +748,47 @@ export const tableConfig = {
       },
       { name: 'watersizeunits', alias: 'waterSizeUnits', skipIndex: true },
       { name: 'watertype', alias: 'waterType' },
+    ],
+    materializedViews: [
+      {
+        name: 'tmdl_assessments',
+        columns: [
+          { name: 'assessmentunitid' },
+          { name: 'assessmentunitname' },
+          { name: 'organizationid' },
+          { name: 'organizationname' },
+          { name: 'region' },
+          { name: 'state' },
+        ],
+      },
+      {
+        name: 'tmdl_actions',
+        columns: [
+          { name: 'actionid' },
+          { name: 'actionname' },
+          { name: 'actionagency' },
+        ],
+      },
+      {
+        name: 'tmdl_addressedparameter',
+        columns: [{ name: 'addressedparameter' }],
+      },
+      {
+        name: 'tmdl_explicitmarginofsafety',
+        columns: [{ name: 'explicitmarginofsafety' }],
+      },
+      {
+        name: 'tmdl_implicitmarginofsafety',
+        columns: [{ name: 'implicitmarginofsafety' }],
+      },
+      {
+        name: 'tmdl_npdesidentifier',
+        columns: [{ name: 'npdesidentifier' }],
+      },
+      {
+        name: 'tmdl_otheridentifier',
+        columns: [{ name: 'otheridentifier' }],
+      },
     ],
   },
 };

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -647,6 +647,46 @@ export async function trimNationalDownloads(pool) {
   });
 }
 
+// Creates an individual index
+async function createIndividualIndex(
+  client,
+  column,
+  count,
+  indexCount,
+  indexTableName,
+  tableName,
+) {
+  if (column.skipIndex) return count;
+
+  const sortOrder = column.indexOrder || 'asc';
+  const collate = column.type ? '' : 'COLLATE pg_catalog."default"';
+  const indexName = `${indexTableName}_${column.name}_${sortOrder}`;
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS ${indexName}
+      ON ${tableName} USING btree
+      (${column.name} ${collate} ${sortOrder} NULLS LAST)
+      TABLESPACE pg_default
+  `);
+  count += 1;
+  log.info(
+    `${tableName}: Created index (${count} of ${indexCount}): ${indexName}`,
+  );
+
+  if (column.includeGinIndex) {
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS ${indexName}_gin
+        ON ${tableName} USING gin (${column.name} gin_trgm_ops);
+    `);
+    count += 1;
+    log.info(
+      `${tableName}: Created index (${count} of ${indexCount}): ${indexName}_gin`,
+    );
+  }
+
+  return count;
+}
+
 // Build the query for creating the indexes
 async function createIndexes(client, overrideWorkMemory, tableName) {
   const indexTableName = tableName.replaceAll('_', '');
@@ -668,33 +708,54 @@ async function createIndexes(client, overrideWorkMemory, tableName) {
     if (col.includeGinIndex) indexCount += 1;
   });
 
+  // create indexes for the table
   let count = 0;
   for (const column of table.columns) {
-    if (column.skipIndex) continue;
+    count = await createIndividualIndex(
+      client,
+      column,
+      count,
+      indexCount,
+      indexTableName,
+      tableName,
+    );
+  }
 
-    const sortOrder = column.indexOrder || 'asc';
-    const collate = column.type ? '' : 'COLLATE pg_catalog."default"';
-    const indexName = `${indexTableName}_${column.name}_${sortOrder}`;
-
+  // create materialized views for the table
+  count = 0;
+  for (const mv of table.materializedViews) {
     await client.query(`
-      CREATE INDEX IF NOT EXISTS ${indexName}
-        ON ${tableName} USING btree
-        (${column.name} ${collate} ${sortOrder} NULLS LAST)
-        TABLESPACE pg_default
+      CREATE MATERIALIZED VIEW IF NOT EXISTS ${mv.name}
+      AS
+      SELECT DISTINCT ${mv.columns.map((col) => col.name).join(', ')}
+      FROM ${tableName} 
+
+      WITH DATA;
     `);
     count += 1;
     log.info(
-      `${tableName}: Created index (${count} of ${indexCount}): ${indexName}`,
+      `${tableName}: Created materialized view (${count} of ${table.materializedViews.length}): ${mv.name}`,
     );
 
-    if (column.includeGinIndex) {
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS ${indexName}_gin
-          ON ${tableName} USING gin (${column.name} gin_trgm_ops);
-      `);
-      count += 1;
-      log.info(
-        `${tableName}: Created index (${count} of ${indexCount}): ${indexName}_gin`,
+    indexCount = 0;
+    mv.columns.forEach((col) => {
+      if (col.skipIndex) return;
+
+      indexCount += 1;
+      if (col.includeGinIndex) indexCount += 1;
+    });
+
+    // create indexes for the materialized view
+    let mvIndexCount = 0;
+    const mvIndexTableName = mv.name.replaceAll('_', '');
+    for (const column of mv.columns) {
+      mvIndexCount = await createIndividualIndex(
+        client,
+        column,
+        mvIndexCount,
+        indexCount,
+        mvIndexTableName,
+        mv.name,
       );
     }
   }


### PR DESCRIPTION
## Related Issues:
* [EQ-209](https://jira.epa.gov/browse/EQ-209)

## Main Changes:
* Switched to materialized views for columns that require distinct queries. This should run fast more consistentently. I did a test on the dev site and a materialized view for assessmentunitname on the catchment_correspondence table has about 600k rows vs the ~50 million rows of the main table.
  * The `values` service will fall back on a distinct query on the table, if we call this `values` service with filters beyond what any of our materialized views can handle.
  * I made this fairly easy to configure, so we should be able to accomodate dependent filters if EPA wants to. I still think if we go that route that we should keep it very limited.
    * I did go ahead and make some groupings that made sense (i.e., assessmentunitid, assessmentunitname, organizationid, and organizationname in one materialized view).
  * The table config also creates indexes on materialized views in the same way we do for tables. We may be able to remove some of these indexes later on.
* Updated our distinct query to filter out nulls.

## Steps To Test:
1. Ensure your env variables are set to your local db
2. Run the etl
3. Verify it runs successfully and creates materialized views
4. Start the app
5. Verify it runs and the drop down queries still work

## TODO:
- [ ] Merge this in and test on dev site
