### PR TITLE
Feature/224 update to eq glossary

### DIFF
--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -16,7 +16,7 @@ import { Alert } from 'components/alert';
 import { Checkbox } from 'components/checkbox';
 import { Checkboxes } from 'components/checkboxes';
 import { CopyBox } from 'components/copyBox';
-import { GlossaryPanel, GlossaryTerm } from 'components/glossaryPanel';
+import { GlossaryPanel } from 'components/glossaryPanel';
 import { InfoTooltip } from 'components/infoTooltip';
 import { Loading } from 'components/loading';
 import { DownloadModal } from 'components/downloadModal';
@@ -247,10 +247,7 @@ export function QueryBuilder() {
           </AccordionItem>
 
           <AccordionItem heading="Advanced API Queries">
-            <h4>
-              {/* TODO - Remove the glossary linkage before production deployment */}
-              <GlossaryTerm term="Acidity">Current Query</GlossaryTerm>
-            </h4>
+            <h4>Current Query</h4>
             <CopyBox
               testId="current-query-copy-box-container"
               text={`${window.location.origin}${

--- a/etl/app/content-private/services.json
+++ b/etl/app/content-private/services.json
@@ -3,7 +3,7 @@
     "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
   },
   "domainValues": "https://attains.epa.gov/attains-public/api/domains",
-  "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary",
+  "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/vocabs/name/Expert%20Query%20Glossary/terms/full",
   "materializedViews": "https://ordspub.epa.gov/ords/attains_eq/",
   "stateCodes": "https://attains.epa.gov/attains-public/api/states"
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-224](https://jira.epa.gov/browse/EQ-224)

## Main Changes:
* Updated etl to point to the expert query glossary.
* Removed glossary term pointing to the HMW glossary. 
* Updated the github actions secrets to have the new glossary api key

## Steps To Test:
1. Update the `GLOSSARY_AUTH` environment variable in your `etl/.env.local` (see teams for the value you need)
2. Run `npm run etl_glossary`
3. Start the app
4. Verify the glossary just has a single term `Test EQ`
5. Verfy the `Current Query` text is no longer linked to the glossary

## TODO:
- [ ] Merge this in, run etl glossary on the dev site, and then retest on owapps-dev.
