### PR TITLE
Feature/56 setup google analytics

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -115,6 +115,157 @@
         f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', 'GTM-L8ZB');
     </script>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-NSTQYKFRSE"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-NSTQYKFRSE');
+    </script>
+    <!-- Google Analytics -->
+    <script>
+      // Prevent scroll restoration. This is used to avoid issues with browsers
+      // scrolling to odd positions after the page finishes loading
+      history.scrollRestoration = 'manual';
+
+      function addGoogleAnalyticsObject() {
+        (function (i, s, o, g, r, a, m) {
+          i['GoogleAnalyticsObject'] = r;
+          (i[r] =
+            i[r] ||
+            function () {
+              (i[r].q = i[r].q || []).push(arguments);
+            }),
+            (i[r].l = 1 * new Date());
+          (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+          a.async = 1;
+          a.src = g;
+          m.parentNode.insertBefore(a, m);
+        })(
+          window,
+          document,
+          'script',
+          '//www.google-analytics.com/analytics.js',
+          'ga',
+        );
+      }
+
+      // Wrapper for logging to GA which adds the target to the command
+      function logToGa(command, ...props) {
+        if (!window.ga) return;
+        ga(`${window.gaTarget}.${command}`, ...props);
+      }
+
+      // get origin for mapping proxy calls
+      const loc = window.location;
+      const origin =
+        loc.origin + (loc.hostname === 'localhost' ? '' : '/expertquery');
+
+      //Only setup the logging for public sites, ie don't log from localhost
+      window.gaTarget = '';
+      if (
+        window.location.hostname.indexOf('epa.gov') > -1 ||
+        window.location.hostname === 'owapps-prod.app.cloud.gov'
+      ) {
+        //EPA (Production) - Just initialize the EQ logs by setting gaTarget
+        window.gaTarget = 'EPA';
+      } else if (window.location.hostname === 'owapps-stage.app.cloud.gov') {
+        addGoogleAnalyticsObject();
+        ga('create', 'UA-37504877-13', 'auto', 'ERG'); //Stage
+        window.gaTarget = 'ERG';
+        logToGa('send', 'pageview');
+      } else if (
+        window.location.hostname === 'owapps-dev.app.cloud.gov' ||
+        window.location.hostname === 'localhost'
+      ) {
+        addGoogleAnalyticsObject();
+        ga('create', 'UA-37504877-12', 'auto', 'ERG'); //Dev
+        window.gaTarget = 'ERG';
+        logToGa('send', 'pageview');
+      }
+
+      //Only setup the logging for public sites, ie don't log from localhost
+      if (gaTarget) {
+        // create the locationChange event
+        const locationChangeEvent = new Event('locationchange');
+
+        // create the location change event listener
+        window.addEventListener('locationchange', function (event) {
+          logToGa('set', 'page', window.location.pathname);
+          logToGa('send', 'pageview');
+        });
+
+        // Modify the pushState, replaceState and popState events so they
+        // will trigger the locationchange event.
+        const pushState = history.pushState;
+        history.pushState = function () {
+          pushState.apply(history, arguments);
+          window.dispatchEvent(locationChangeEvent);
+        };
+        const replaceState = history.replaceState;
+        history.replaceState = function () {
+          replaceState.apply(this, arguments);
+          window.dispatchEvent(locationChangeEvent);
+        };
+        window.addEventListener('popstate', function () {
+          window.dispatchEvent(locationChangeEvent);
+        });
+
+        window.addEventListener('click', function (event) {
+          //Button clicks
+          if (event.target.onclick && event.target.textContent) {
+            const text = event.target.textContent.trim();
+            const title = event.target.title.trim();
+
+            //Log to Google Analytics
+            const action = title
+              ? 'ow-eq1-' + text + ' - ' + title
+              : 'ow-eq1-' + text;
+            logToGa(
+              'send',
+              'event',
+              'buttonClick',
+              action,
+              window.location.pathname,
+            );
+          }
+
+          //Link clicks
+          if (event.target.tagName.toLowerCase() === 'a') {
+            const href = event.target.href;
+            const action = 'ow-eq1-' + event.target.text.trim();
+
+            const extension = href.split('.').pop;
+            const category =
+              window.location.hostname === event.target.hostname
+                ? //Part of the EQ application
+                  extension === '.pdf' || extension === '.zip'
+                  ? 'Download'
+                  : 'Internal'
+                : 'External'; //External EPA Hyperlink
+
+            //Log to Google Analytics
+            logToGa('send', 'event', category, action, href);
+          }
+        });
+
+        window.addEventListener('error', function (event) {
+          window.logToGa('send', 'exception', {
+            exDescription: `${event.error.message}${event.error.stack}`,
+            exFatal: true,
+          });
+
+          return true;
+        });
+      }
+    </script>
+    <!-- End Google Analytics-->
   </head>
   <body id="top">
     <div class="skiplinks" role="navigation" aria-labelledby="skip-to-main">

--- a/app/client/public/robots.txt
+++ b/app/client/public/robots.txt
@@ -1,3 +1,3 @@
-Sitemap: https://expertquery.epa.gov/sitemap.xml
+Sitemap: https://owapps.epa.gov/expertquery/sitemap.xml
 User-agent: *
 Disallow:

--- a/app/client/public/sitemap.xml
+++ b/app/client/public/sitemap.xml
@@ -1,7 +1,43 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
     <url>
-        <loc>https://expertquery.epa.gov/</loc>
+        <loc>https://owapps.epa.gov/expertquery/api-documentation</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/actions</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/assessmentUnits</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/assessmentUnitsMonitoringLocations</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/assessments</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/catchmentCorrespondence</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/sources</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/attains/tmdl</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://owapps.epa.gov/expertquery/national-downloads</loc>
         <changefreq>weekly</changefreq>
     </url>
 </urlset>

--- a/app/client/src/components/app.tsx
+++ b/app/client/src/components/app.tsx
@@ -15,6 +15,14 @@ import { cloudSpace, getData, serverBasePath, serverUrl } from '../config';
 // types
 import type { Content } from 'contexts/content';
 
+declare global {
+  interface Window {
+    ga: Function;
+    gaTarget: string;
+    logToGa: Function;
+  }
+}
+
 /** Custom hook to fetch static content */
 function useFetchedContent() {
   const contentDispatch = useContentDispatch();

--- a/app/client/src/components/errorBoundary.tsx
+++ b/app/client/src/components/errorBoundary.tsx
@@ -1,6 +1,6 @@
-import { Component, ErrorInfo, ReactNode } from "react";
+import { Component, ErrorInfo, ReactNode } from 'react';
 // components
-import { Message } from "components/message";
+import { Message } from 'components/message';
 
 type Props = {
   children: ReactNode;
@@ -20,7 +20,13 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error("Uncaught error:", error, errorInfo);
+    console.error('Uncaught error:', error, errorInfo);
+
+    if (!window.gaTarget) return;
+    window.logToGa('send', 'exception', {
+      exDescription: `${error}${errorInfo.componentStack}`,
+      exFatal: true,
+    });
   }
 
   public render() {
@@ -28,7 +34,7 @@ export class ErrorBoundary extends Component<Props, State> {
     const { hasError } = this.state;
 
     if (hasError) {
-      return <Message type="error" text={"Something went wrong."} />;
+      return <Message type="error" text={'Something went wrong.'} />;
     }
 
     return children;

--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -14,11 +14,6 @@ type Props = {
 export type Content = {
   services: {
     eqDataApi: string;
-    googleAnalyticsMapping: Array<{
-      urlLookup: string;
-      wildcardUrl: string;
-      name: string;
-    }>;
   };
   alertsConfig: {
     [page: string]: {

--- a/app/server/app/content/config/services.json
+++ b/app/server/app/content/config/services.json
@@ -1,10 +1,3 @@
 {
-  "eqDataApi": "",
-  "googleAnalyticsMapping": [
-    {
-      "urlLookup": "eqDataApi",
-      "wildcardUrl": "{urlLookup}*",
-      "name": "expert query - data api"
-    }
-  ]
+  "eqDataApi": ""
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-56](https://jira.epa.gov/browse/EQ-56)
* [EQ-205](https://jira.epa.gov/browse/EQ-205)

## Main Changes:
* Added google analytics logging to the app, similarly to how we do it in HMW. 
  * I left off the web service logging for now, since we will have `api.data.gov` and will use the cloud.gov logs for tracking problems. This simplifies the code around Google Analytics.
* Updated the `sitemap.xml` and `robots.txt` files to have the correct values. 
  * Note: I did put in the api documentation page as `api-documentation` on the assumption that we are going to change that. I'll update this if we end up using a different url.

## Steps To Test:
1. Open up google analytics for expert query dev
2. Click around in the app and view the events being logged
    * Ignore any historical events related to web services, since I pulled that code out. 
    * Verify the events look ok and the text is understandable
