### PR TITLE
Feature/246 clear out national downloads

### DIFF
--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -666,7 +666,9 @@ export async function trimSchema(pool, s3Config) {
 export async function trimNationalDownloads(pool) {
   // get list of currently stored schemas
   const schemas = await pool
-    .query('SELECT s3_julian FROM logging.etl_schemas')
+    .query(
+      'SELECT s3_julian FROM logging.etl_schemas WHERE s3_julian IS NOT NULL',
+    )
     .catch((err) => {
       log.warn(`Could not query schemas: ${err}`);
     });

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -468,6 +468,7 @@ export async function runJob(s3Config, checkIfReady = true) {
   try {
     await runLoad(pool, s3Config, s3Julian);
     await trimSchema(pool, s3Config);
+    if (!environment.isLocal) await trimNationalDownloads(pool);
     await updateEtlStatus(pool, 'database', 'success');
   } catch (err) {
     log.warn(`Run failed, continuing to schedule cron task: ${err}`);
@@ -665,16 +666,14 @@ export async function trimSchema(pool, s3Config) {
 export async function trimNationalDownloads(pool) {
   // get list of currently stored schemas
   const schemas = await pool
-    .query('SELECT schema_name FROM logging.etl_schemas')
+    .query('SELECT s3_julian FROM logging.etl_schemas')
     .catch((err) => {
       log.warn(`Could not query schemas: ${err}`);
     });
   if (!schemas?.rowCount) return;
 
   // build a list of directories (schemas) to leave on S3
-  const dirsToIgnore = schemas.rows.map((schema) => {
-    return schema.schema_name.replace('schema_', '');
-  });
+  const dirsToIgnore = schemas.rows.map((schema) => schema.s3_julian);
   dirsToIgnore.push('latest');
 
   deleteDirectory({


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/EQ-246

## Main Changes:
* Added code to clear out old folders in national downloads. 
  * Since we already have some code to do this I just updated the existing code work with our new etl process. 
  * I figure this will be better than using an S3 policy because 1 it will ensure the folders in the s3 bucket match what we have in the database and 2 we won't run into issues where the S3 folder associated with the active database gets deleted because we don't run the etl as often on stage.
  * I made this code get skipped when running locally, since we just manually control what's in the national-downloads folder.

## Steps To Test:
Not really a good way to test this, so just verify the code changes look good.

This code was tested and in use before we switched to using the s3 => postgres extension, so this should work fine. The only real change to it was switching from using the `schema_name` column to using the `s3_julian` column.

## TODO:
- [ ] Merge this in, run the etl, and verify the correct folders were deleted. I already took backups of what is in there now, so we should be able to restore if necessary.
