### PR TITLE
Feature/147 test filter inputs

### DIFF
--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -189,7 +189,7 @@ export function QueryBuilder() {
       {profile && (
         <Accordion>
           <AccordionItem heading="Filters" initialExpand>
-            <div className="display-flex width-full justify-content-center">
+            <div className="display-flex width-full flex-justify-center">
               <Button onClick={openClearConfirmation} color="white">
                 Clear Search
               </Button>

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1050,7 +1050,6 @@ function addDomainAliases(values: DomainOptions): Required<DomainOptions> {
     associatedActionAgency: values.actionAgency,
     associatedActionStatus: values.assessmentUnitStatus,
     associatedActionType: values.actionType,
-    parameter: values.parameterName,
     pollutant: values.parameterName,
   };
 }

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -13,7 +13,6 @@ export type AliasedField =
   | 'associatedActionAgency'
   | 'associatedActionStatus'
   | 'associatedActionType'
-  | 'parameter'
   | 'pollutant';
 
 export type AliasedOptions = {

--- a/app/server/app/config/tableConfig.js
+++ b/app/server/app/config/tableConfig.js
@@ -76,6 +76,10 @@ export const tableConfig = {
           { name: 'state' },
         ],
       },
+      {
+        name: 'actions_parameter',
+        columns: [{ name: 'parameter' }],
+      },
     ],
   },
   assessments: {

--- a/etl/app/config/tableConfig.js
+++ b/etl/app/config/tableConfig.js
@@ -76,6 +76,10 @@ export const tableConfig = {
           { name: 'state' },
         ],
       },
+      {
+        name: 'actions_parameter',
+        columns: [{ name: 'parameter' }],
+      },
     ],
   },
   assessments: {

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -32,7 +32,7 @@
   },
   "parameterName": {
     "domainName": "ParameterName",
-    "columns": ["parameter", "parameterName", "pollutant"]
+    "columns": ["parameterName", "pollutant"]
   },
   "parameterStatus": {
     "domainName": "ParameterStatus",

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -1,55 +1,71 @@
 {
   "actionAgency": {
     "domainName": "AgencyCode",
+    "columns": ["actionAgency", "associatedActionAgency"],
     "valueField": "name"
   },
   "actionType": {
     "domainName": "ActionType",
+    "columns": ["actionType", "associatedActionType"],
     "labelField": "code"
   },
   "assessmentTypes": {
-    "domainName": "AssessmentTypeCode"
+    "domainName": "AssessmentTypeCode",
+    "columns": ["assessmentTypes"]
   },
   "assessmentUnitStatus": {
-    "domainName": "StatusIndicator"
+    "domainName": "StatusIndicator",
+    "columns": ["assessmentUnitStatus"]
   },
   "delistedReason": {
     "domainName": "DelistingReasonCode",
+    "columns": ["delistedReason"],
     "valueField": "name"
   },
   "locationTypeCode": {
-    "domainName": "LocationTypeCode"
+    "domainName": "LocationTypeCode",
+    "columns": ["locationTypeCode"]
   },
   "parameterGroup": {
-    "domainName": "ParameterGroupCodeType"
+    "domainName": "ParameterGroupCodeType",
+    "columns": ["parameterGroup"]
   },
   "parameterName": {
-    "domainName": "ParameterName"
+    "domainName": "ParameterName",
+    "columns": ["parameter", "parameterName", "pollutant"]
   },
   "parameterStatus": {
-    "domainName": "ParameterStatus"
+    "domainName": "ParameterStatus",
+    "columns": ["parameterStatus"]
   },
   "sourceName": {
-    "domainName": "SourceName"
+    "domainName": "SourceName",
+    "columns": ["sourceName"]
   },
   "sourceType": {
-    "domainName": "PollutantSourceType"
+    "domainName": "PollutantSourceType",
+    "columns": ["sourceType"]
   },
   "stateIrCategory": {
-    "domainName": "StateIRCategoryCode"
+    "domainName": "StateIRCategoryCode",
+    "columns": ["stateIrCategory"]
   },
   "useClassName": {
     "domainName": "UseClassType",
+    "columns": ["useClassName"],
     "valueField": "name"
   },
   "useName": {
-    "domainName": "UseName"
+    "domainName": "UseName",
+    "columns": ["useName"]
   },
   "useSupport": {
-    "domainName": "UseAttainmentCode"
+    "domainName": "UseAttainmentCode",
+    "columns": ["useSupport"]
   },
   "waterType": {
     "domainName": "WaterTypeUnitsCode",
+    "columns": ["waterType"],
     "labelField": "context",
     "valueField": "context"
   }

--- a/etl/app/content-private/domainValueMappings.json
+++ b/etl/app/content-private/domainValueMappings.json
@@ -14,7 +14,8 @@
     "domainName": "StatusIndicator"
   },
   "delistedReason": {
-    "domainName": "DelistingReasonCode"
+    "domainName": "DelistingReasonCode",
+    "valueField": "name"
   },
   "locationTypeCode": {
     "domainName": "LocationTypeCode"

--- a/etl/app/server/etlJob.js
+++ b/etl/app/server/etlJob.js
@@ -13,8 +13,7 @@ export default async function etlJob() {
     return;
   }
 
-  s3.syncDomainValues(s3Config);
-
   // Create and load new schema
   await database.runJob(s3Config);
+  await s3.syncDomainValues(s3Config);
 }

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -193,16 +193,18 @@ function fetchSingleDomain(name, mapping, pool) {
         });
 
       // Add any column values not represented by domain values service
-      const colValues = await queryColumnValues(pool, name);
-      colValues.forEach((value) => {
-        if (valuesAdded.has(value)) return;
-        // Warn about mismatch, since value added here may not have the desired label
-        log.warn(
-          `Column value missing from "${mapping.domainName}" domain service: ${value}`,
-        );
-        valuesAdded.add(value);
-        values.push({ label: value, value });
-      });
+      for (const colAlias of mapping.columns) {
+        const colValues = await queryColumnValues(pool, colAlias);
+        colValues.forEach((value) => {
+          if (valuesAdded.has(value)) return;
+          // Warn about mismatch, since value added here may not have the desired label
+          log.warn(
+            `Column value missing from "${mapping.domainName}" domain service: ${value}`,
+          );
+          valuesAdded.add(value);
+          values.push({ label: value, value });
+        });
+      }
 
       const output = {};
       output[name] = values;

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -164,22 +164,8 @@ function fetchSingleDomain(name, mapping, pool) {
         );
       }
 
-      // Filter out specific values from the result
-      let filteredData = res.data;
-      if ('filters' in mapping) {
-        mapping.filters.forEach(([field, filter]) => {
-          filteredData = filteredData.filter((domainValue) => {
-            if (Array.isArray(filter)) {
-              return !filter.includes(domainValue[field]);
-            } else {
-              return filter !== domainValue[field];
-            }
-          });
-        });
-      }
-
       const valuesAdded = new Set();
-      let values = filteredData
+      let values = res.data
         .map((value) => {
           return {
             label: value[mapping.labelField ?? 'name'],


### PR DESCRIPTION
## Related Issues:
* [EQ-147](https://jira.epa.gov/browse/EQ-147)

## Main Changes:
* Added a step to the ETL domain values task that checks if any column values are missing from the retrieved domain values. If so, the values are added to the domain values, and a warning is logged.
  * This brought one mapping issue to light that was fixed, and another mapping into question: as mentioned in the ticket, the `parameter` column has a number of values that aren't represented in the ParameterName domain service, although most are. For now, the field has been updated to pull from database values, but we may still want to mention this to the EPA team.
* Moved the domain values synchronization task after the main database job.
* Manually tested all fields in the UI.

## Steps To Test:
1. While connected to a local database, run the ETL process.
2. Confirm that the main ETL job runs before the domain values task.
3. Confirm that no warnings about missing values are logged when the domain values task is executing.
4. In the UI, ensure that the `parameter` field of the `actions` profile is querying the database for its values.
5. Test other UI fields at will.
