### PR TITLE
Bugfix/domain values running 15 minutes

### DIFF
--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -7,7 +7,7 @@ import { setTimeout } from 'timers/promises';
 import { getEnvironment } from './utilities/environment.js';
 import { log } from './utilities/logger.js';
 import * as profiles from './profiles/index.js';
-import { deleteDirectory, readS3File } from './s3.js';
+import { deleteDirectory, readS3File, syncDomainValues } from './s3.js';
 // config
 import { tableConfig } from '../config/tableConfig.js';
 
@@ -461,6 +461,7 @@ export async function runJob(s3Config, checkIfReady = true) {
     await trimSchema(pool, s3Config);
     if (!environment.isLocal) await trimNationalDownloads(pool);
     await updateEtlStatus(pool, 'database', 'success');
+    await syncDomainValues(s3Config, pool);
   } catch (err) {
     log.warn(`Run failed, continuing to schedule cron task: ${err}`);
     await updateEtlStatus(pool, 'database', 'failed');

--- a/etl/app/server/etlJob.js
+++ b/etl/app/server/etlJob.js
@@ -15,5 +15,4 @@ export default async function etlJob() {
 
   // Create and load new schema
   await database.runJob(s3Config);
-  await s3.syncDomainValues(s3Config);
 }

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -215,8 +215,8 @@ function fetchSingleDomain(name, mapping, pool) {
   };
 }
 
-export async function syncDomainValues(s3Config) {
-  const pool = startConnPool();
+export async function syncDomainValues(s3Config, pool = null) {
+  if (!pool) pool = startConnPool();
   await updateEtlStatus(pool, 'domain_values', 'running');
 
   try {
@@ -245,7 +245,7 @@ export async function syncDomainValues(s3Config) {
     log.error(`Sync Domain Values failed! ${err}`);
     await updateEtlStatus(pool, 'domain_values', 'failed');
   } finally {
-    endConnPool(pool);
+    if (!pool) endConnPool(pool);
   }
 }
 

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -215,8 +215,8 @@ function fetchSingleDomain(name, mapping, pool) {
   };
 }
 
-export async function syncDomainValues(s3Config, pool = null) {
-  if (!pool) pool = startConnPool();
+export async function syncDomainValues(s3Config, poolParam = null) {
+  const pool = poolParam ? poolParam : startConnPool();
   await updateEtlStatus(pool, 'domain_values', 'running');
 
   try {
@@ -245,7 +245,7 @@ export async function syncDomainValues(s3Config, pool = null) {
     log.error(`Sync Domain Values failed! ${err}`);
     await updateEtlStatus(pool, 'domain_values', 'failed');
   } finally {
-    if (!pool) endConnPool(pool);
+    if (!poolParam) endConnPool(pool);
   }
 }
 


### PR DESCRIPTION
## Related Issues:
* None

## Main Changes:
* Fixed issue of the etl for domain values running every 15 minutes.
  * The new warnings being logged (introduced via #83) made it apparent that the etl for domain values was being ran every 15 minutes instead of weekly like the database.

## Steps To Test:
1. Verify your environment is pointing to the local database
2. Run `npm run start` from the etl folder
3. Verify the etl succeeds
4. Run `npm run etl_domain_values` from the etl folder
5. Verify the etl domain values succeeds
