### PR TITLE
Feature/270 remove side navigation

### DIFF
--- a/app/client/src/components/page.tsx
+++ b/app/client/src/components/page.tsx
@@ -16,27 +16,26 @@ export function Page({ children }: PageProps) {
       ? `${location.protocol}//${location.hostname}:9090`
       : serverUrl;
 
-  const navItems = {
-    attains: { path: '/attains', label: 'Query ATTAINS Data' },
-    nationalDownloads: {
-      path: '/national-downloads',
-      label: 'National Downloads',
-    },
-    apiDocs: { path: '/api-documentation', label: 'API Documentation' },
-  };
-
   return (
     <div className="l-page has-footer">
-      <div className="l-constrain maxw-widescreen">
+      <div className="l-constrain">
         <div className="l-page__header">
-          <div className="l-page__header-first usa-logo">
+          <div className="l-page__header-first usa-logo margin-top-0">
             <h1 className="web-area-title usa-logo__text">
               <NavLink to="/">Expert Query</NavLink>
             </h1>
           </div>
-          <div className="l-page__header-last">
+          <div className="l-page__header-last grid-row">
             <a
-              className="header-link margin-right-3"
+              className="margin-left-2 tablet:margin-left-0 margin-right-3 text-no-underline tablet:grid-col-auto"
+              href={`${serverUrl}/national-downloads`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              National Downloads
+            </a>
+            <a
+              className="margin-left-2 tablet:margin-left-0 margin-right-3 text-no-underline tablet:grid-col-auto"
               href={`${baseUrl}/api/getFile/path/Expert-Query-Users-Guide.pdf`}
               target="_blank"
               rel="noopener noreferrer"
@@ -44,8 +43,8 @@ export function Page({ children }: PageProps) {
               User's Guide (PDF)
             </a>
             <a
-              className="header-link"
-              href="https://www.epa.gov/expertquery/forms/contact-us-about-expert-query"
+              className="margin-left-2 tablet:margin-left-0 margin-right-3 text-no-underline tablet:grid-col-auto"
+              href="https://www.epa.gov/waterdata/forms/contact-us-about-water-data-and-tools"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -54,29 +53,7 @@ export function Page({ children }: PageProps) {
           </div>
         </div>
 
-        <div className="l-sidebar l-sidebar--reversed">
-          <div className="l-sidebar__main">
-            <article className="article">{children}</article>
-          </div>
-          <div className="l-sidebar__sidebar">
-            <nav aria-label="Side navigation,">
-              <ul className="usa-sidenav">
-                {Object.entries(navItems).map(([key, item]) => (
-                  <li key={key} className="usa-sidenav__item">
-                    <NavLink
-                      to={item.path}
-                      className={({ isActive }) =>
-                        isActive ? 'usa-current' : ''
-                      }
-                    >
-                      {item.label}
-                    </NavLink>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </div>
-        </div>
+        <article className="article">{children}</article>
       </div>
 
       <div className="l-page__footer">

--- a/app/client/src/config/options.tsx
+++ b/app/client/src/config/options.tsx
@@ -34,13 +34,7 @@ export const dataProfile = Object.entries(profiles)
   .map(([id, profile]) => {
     return {
       value: id,
-      label: (
-        <p className="margin-1">
-          <b>{profile.label}</b>
-          <br />
-          <em>{profile.description}</em>
-        </p>
-      ),
+      label: profile.label,
     } as const;
   });
 

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1,6 +1,7 @@
 import { debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import {
+  Link,
   Outlet,
   useNavigate,
   useOutletContext,
@@ -76,9 +77,33 @@ export function Home() {
     initializeFilters,
   });
 
-  const profileRefreshDate = profile
-    ? content.data.metadata?.[profile]?.timestamp
-    : null;
+  const formatProfileOptionLabel = useCallback(
+    (option: Option) => {
+      const description = Object.entries(profiles).find(
+        ([id, _config]) => id === option.value,
+      )?.[1].description;
+      const refreshDate =
+        content.status === 'success'
+          ? Object.entries(content.data.metadata).find(
+              ([id, _metadata]) => id === option.value,
+            )?.[1].timestamp
+          : null;
+      return (
+        <div className="margin-1">
+          <div className="display-flex flex-justify flex-wrap margin-bottom-1">
+            <b className="font-ui-md margin-right-4">{option.label}</b>
+            {refreshDate && (
+              <em className="font-ui-xs">
+                <b>Refresh date:</b> {new Date(refreshDate).toLocaleString()}
+              </em>
+            )}
+          </div>
+          {description}
+        </div>
+      );
+    },
+    [content],
+  );
 
   if (content.status === 'pending') return <Loading />;
 
@@ -109,26 +134,30 @@ export function Home() {
               <h3>Data Profile</h3>
               <Select
                 id="select-data-profile"
+                classNames={{
+                  option: () => 'border-bottom border-base-lighter',
+                }}
                 instanceId="instance-select-data-profile"
                 aria-label="Select a data profile"
+                formatOptionLabel={formatProfileOptionLabel}
                 onChange={handleProfileChange}
                 options={staticOptions.dataProfile}
                 placeholder="Select a data profile..."
+                styles={{
+                  menu: (baseStyles) => ({
+                    ...baseStyles,
+                    maxHeight: '75vh',
+                  }),
+                  menuList: (baseStyles) => ({
+                    ...baseStyles,
+                    maxHeight: '75vh',
+                  }),
+                }}
                 value={profileOption}
               />
 
               {profile && (
                 <>
-                  {profileRefreshDate && (
-                    <p>
-                      {profiles[profile].label} profile data last refreshed{' '}
-                      <strong>
-                        {new Date(profileRefreshDate).toLocaleString()}
-                      </strong>
-                      .
-                    </p>
-                  )}
-
                   <Outlet
                     context={{
                       filterHandlers,
@@ -266,6 +295,8 @@ export function QueryBuilder() {
           </AccordionItem>
 
           <AccordionItem heading="Advanced API Queries">
+            Visit our <Link to="/api-documentation">API Documentation</Link>{' '}
+            page to learn more.
             <h4>Current Query</h4>
             <CopyBox
               testId="current-query-copy-box-container"
@@ -449,7 +480,7 @@ function FilterFields({
   );
 
   return (
-    <div className="grid-gap grid-row">
+    <div className="grid-gap-2 grid-row">
       {fieldsJsx.map(([field, key]) => (
         <div className="desktop:grid-col-4 tablet:grid-col-6" key={key}>
           {field}
@@ -765,6 +796,10 @@ function SelectFilter<
     <Select
       aria-label={`${filterLabel} input`}
       className="width-full"
+      classNames={{
+        container: () => 'font-ui-xs',
+        menuList: () => 'font-ui-xs',
+      }}
       formatOptionLabel={formatOptionLabel}
       inputId={`input-${filterKey}`}
       instanceId={`instance-${filterKey}`}

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -1,4 +1,5 @@
 import { ReactComponent as Exit } from '@uswds/uswds/img/usa-icons/launch.svg';
+import { Link } from 'react-router-dom';
 // components
 import { Alert } from 'components/alert';
 import { Loading } from 'components/loading';
@@ -25,11 +26,6 @@ export function NationalDownloads() {
     <>
       <div>
         <h2>National Downloads</h2>
-        <ul className="usa-list">
-          <li>
-            <a href="#attains">ATTAINS Data</a>
-          </li>
-        </ul>
         <hr />
         <Summary heading="Description">
           <p>
@@ -65,6 +61,7 @@ function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
     return (
       <section className="margin-top-6" id="attains">
         <h3 className="text-primary">ATTAINS Data</h3>
+        Go to the <Link to="/attains">ATTAINS Query</Link> page.
         <table className="margin-x-auto usa-table usa-table--stacked width-full">
           <thead>
             <tr>
@@ -82,7 +79,7 @@ function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
                 <tr key={profile}>
                   <th scope="row" data-label="Download link">
                     <a href={fileInfo.url}>
-                      {profiles[profile as Profile].label} Profile Data
+                      {profiles[profile as Profile].label} Profile
                       <Exit
                         aria-hidden="true"
                         className="height-2 margin-left-05 text-primary top-05 usa-icon width-2"


### PR DESCRIPTION
## Related Issues:

- [EQ-262](https://jira.epa.gov/browse/EQ-262)
- [EQ-270](https://jira.epa.gov/browse/EQ-270)

## Main Changes:

- Removed the side site navigation, and moved the National Downloads page into
  the top navigation bar. Also updated the styles of this bar to account for
  small screens.
- Moved the API Documentation link to an in-sentence link in the Advanced API
  Queries section.
- Added a link back to the query page from the relevant section of the National
  Downloads page.
- Removed the in-page links from the National Downloads page. If we want, we can
  add them back in as the site grows.
- Updated the "Contact Us" link.
- Updated the styles of the Data Profile select input. The refresh times are now
  paired with the corresponding labels, text sizes and styles were changed, and
  the height of the drop-down menu has increased.

## Steps To Test:

1. Test the styles described above across all device sizes.
2. Test the newly added links.
