### PR TITLE
Feature/274 in page navigation

### DIFF
--- a/app/client/public/css/styles.css
+++ b/app/client/public/css/styles.css
@@ -8,6 +8,10 @@
 }
 
 /* --- EPA/USWDS --- */
+.l-constrain {
+  max-width: 75rem;
+}
+
 .usa-site-alert .usa-alert {
   max-width: 1400px;
 }

--- a/app/client/src/components/accordion.tsx
+++ b/app/client/src/components/accordion.tsx
@@ -29,8 +29,8 @@ export function AccordionItem({
   const toggleExpanded = useCallback(() => setExpanded(!expanded), [expanded]);
 
   return (
-    <div className="margin-top-2">
-      <h4 className="usa-accordion__heading">
+    <div className="margin-top-8">
+      <h3 className="usa-accordion__heading">
         <button
           type="button"
           className="usa-accordion__button"
@@ -39,7 +39,7 @@ export function AccordionItem({
         >
           {heading}
         </button>
-      </h4>
+      </h3>
       {expanded && (
         <div
           className="overflow-visible usa-accordion__content usa-prose"

--- a/app/client/src/components/alert.tsx
+++ b/app/client/src/components/alert.tsx
@@ -26,7 +26,6 @@ export function Alert({
       break;
     case 'error':
       alertStyles.push('usa-alert--error');
-      role = 'alert';
       break;
     case 'success':
       alertStyles.push('usa-alert--success');

--- a/app/client/src/components/alert.tsx
+++ b/app/client/src/components/alert.tsx
@@ -14,18 +14,23 @@ export function Alert({
 }: AlertProps) {
   const alertStyles = [...styles];
 
+  let role = 'alert';
   switch (type) {
     case 'info':
       alertStyles.push('usa-alert--info');
+      role = 'region';
       break;
     case 'warning':
       alertStyles.push('usa-alert--warning');
+      role = 'region';
       break;
     case 'error':
       alertStyles.push('usa-alert--error');
+      role = 'alert';
       break;
     case 'success':
       alertStyles.push('usa-alert--success');
+      role = 'status';
       break;
   }
 
@@ -35,7 +40,7 @@ export function Alert({
   return (
     <div
       className={`radius-md usa-alert ${alertStyles.join(' ')}`}
-      role="alert"
+      role={role}
     >
       <div className="usa-alert__body">
         {heading && <h4 className="usa-alert__heading">{heading}</h4>}

--- a/app/client/src/components/downloadModal.tsx
+++ b/app/client/src/components/downloadModal.tsx
@@ -13,7 +13,7 @@ import { serverUrl } from 'config';
 // styles
 import '@reach/dialog/styles.css';
 // types
-import type { FetchState, Primitive, Status } from 'types';
+import type { FetchState, Status } from 'types';
 
 /*
 ## Components
@@ -143,7 +143,9 @@ export function DownloadModal<D extends PostData>({
                   <p>
                     Please refine the search, or visit the{' '}
                     <a
-                      href={`${serverUrl}/national-downloads${dataId ? '#' + dataId : ''}`}
+                      href={`${serverUrl}/national-downloads${
+                        dataId ? '#' + dataId : ''
+                      }`}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -240,7 +242,7 @@ type DownloadModalProps<D extends PostData> = {
 type PostData = {
   columns: string[];
   filters: {
-    [field: string]: Primitive | Primitive[];
+    [field: string]: string | string[];
   };
   options: {
     [field: string]: string;

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -135,11 +135,7 @@ function InPageNavLayoutInner({ children }: { children: ReactNode }) {
   }, [navItems]);
 
   return (
-    <div
-      className={`l-constrain ${
-        navItems.length > 0 ? 'maxw-desktop-lg' : ''
-      } usa-in-page-nav-container`}
-    >
+    <div className="usa-in-page-nav-container">
       {sortedNavItems.length > 0 && (
         <aside className="usa-in-page-nav">
           <nav className="usa-in-page-nav__nav">
@@ -168,7 +164,7 @@ function InPageNavLayoutInner({ children }: { children: ReactNode }) {
           </nav>
         </aside>
       )}
-      <div className="width-full">{children}</div>
+      <div className="flex-fill">{children}</div>
     </div>
   );
 }

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -201,7 +201,7 @@ export function NumberedInPageNavLabel({
 }: NumberedInPageNavLabelProps) {
   return (
     <>
-      <span className="bg-primary display-inline-block height-205 line-height-sans-3 margin-right-05 radius-pill text-center text-white width-205">
+      <span className="bg-primary display-inline-block font-family-mono height-205 line-height-sans-3 margin-right-05 radius-pill text-center text-white width-205">
         {number}
       </span>{' '}
       {children}

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -65,10 +65,10 @@ function InPageNavProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const dispatch: ObserverDispatch = {
-    observe,
-    unobserve,
-  };
+  const dispatch: ObserverDispatch = useMemo(
+    () => ({ observe, unobserve }),
+    [observe, unobserve],
+  );
 
   useEffect(() => {
     return function cleanup() {

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useContext,
   useMemo,
   useState,
@@ -30,13 +31,13 @@ function InPageNavProvider({ children }: { children: ReactNode }) {
   const observer = useMemo(() => {
     const options = {
       rootMargin: '48px 0px -80% 0px',
-      threshold: [1],
+      threshold: 1,
     };
     return new IntersectionObserver((entries: IntersectionObserverEntry[]) => {
       for (const entry of entries) {
         if (
           entry.isIntersecting &&
-          options.threshold.some((t) => entry.intersectionRatio >= t)
+          entry.intersectionRatio >= options.threshold
         ) {
           setActive(entry.target.id);
           return;
@@ -54,7 +55,6 @@ function InPageNavProvider({ children }: { children: ReactNode }) {
   );
 
   const unobserve = useCallback((itemId: string) => {
-    setActive((prev) => (prev === itemId ? '' : prev));
     setNavItems((prev) => {
       return prev.reduce<Array<InPageNavItem>>((current, next) => {
         if (next.id === itemId) {
@@ -127,10 +127,12 @@ function InPageNavLayoutInner({ children }: { children: ReactNode }) {
 
   const sortedNavItems = useMemo(() => {
     const sorted: InPageNavItem[] = [];
-    document.querySelectorAll('.in-page-nav-anchor').forEach((node) => {
-      const navItem = navItems.find((item) => item.id === node.id);
-      if (navItem) sorted.push(navItem);
-    });
+    document
+      .querySelectorAll('[data-role="in-page-nav-anchor"]')
+      .forEach((node) => {
+        const navItem = navItems.find((item) => item.id === node.id);
+        if (navItem) sorted.push(navItem);
+      });
     return sorted;
   }, [navItems]);
 
@@ -189,7 +191,7 @@ export function InPageNavAnchor({
   );
 
   return (
-    <div className="in-page-nav-anchor" id={id} ref={ref}>
+    <div data-role="in-page-nav-anchor" id={id} ref={ref}>
       {children}
     </div>
   );
@@ -201,9 +203,9 @@ export function NumberedInPageNavLabel({
 }: NumberedInPageNavLabelProps) {
   return (
     <>
-      <span className="bg-primary display-inline-block font-family-mono height-205 line-height-sans-3 margin-right-05 radius-pill text-center text-white width-205">
+      <span className="bg-primary display-inline-block font-family-mono height-205 line-height-sans-3 margin-right-1 radius-pill text-center text-white width-205">
         {number}
-      </span>{' '}
+      </span>
       {children}
     </>
   );

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -1,0 +1,263 @@
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useContext,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
+// types
+import type { Dispatch, ReactNode } from 'react';
+
+/*
+## Utils
+*/
+
+function getHeadingId(heading: HTMLHeadingElement) {
+  const baseId = heading.textContent
+    ?.toLowerCase()
+    // Replace non-alphanumeric characters with dashes
+    .replace(/[^a-z\d]/g, '-')
+    // Replace a sequence of two or more dashes with a single dash
+    .replace(/-{2,}/g, '-')
+    // Trim leading or trailing dash (there should only ever be one)
+    .replace(/^-|-$/g, '');
+
+  let id;
+  let suffix = 0;
+  do {
+    id = baseId;
+
+    // To avoid conflicts with existing IDs on the page, loop and append an
+    // incremented suffix until a unique ID is found.
+    suffix += 1;
+    if (suffix > 1) {
+      id += `-${suffix}`;
+    }
+  } while (document.getElementById(id ?? ''));
+
+  return id;
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'REGISTER_NAV_ITEM': {
+      return {
+        ...state,
+        items: [...state.items, action.payload],
+      };
+    }
+    case 'SET_ACTIVE_ITEM': {
+      return {
+        ...state,
+        active: action.payload,
+      };
+    }
+    case 'DEREGISTER_NAV_ITEM': {
+      return {
+        active: state.active === action.payload ? '' : state.active,
+        items: state.items.reduce<State['items']>((current, next) => {
+          if (next.id === action.payload) {
+            return current;
+          } else {
+            return [...current, next];
+          }
+        }, []),
+      };
+    }
+    default:
+      throw new Error(`Unhandled action type: ${action}`);
+  }
+}
+
+/*
+## Contexts
+*/
+
+const StateContext = createContext<State | undefined>(undefined);
+const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
+
+function InPageNavProvider({ children }: { children: ReactNode }) {
+  const initialState: State = { active: '', items: [] };
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+/*
+## Hooks
+*/
+
+function useInPageNavState() {
+  const state = useContext(StateContext);
+
+  if (state === undefined) {
+    throw new Error('useInPageNavState must be called within an InPageNav');
+  }
+
+  return state;
+}
+
+function useInPageNavDispatch() {
+  const dispatch = useContext(DispatchContext);
+
+  if (dispatch === undefined) {
+    throw new Error('useInPageNavDispatch must be called within an InPageNav');
+  }
+
+  return dispatch;
+}
+
+/*
+## Components
+*/
+
+export function InPageNav({ children }: { children: ReactNode }) {
+  return (
+    <InPageNavProvider>
+      <InPageNavInner>{children}</InPageNavInner>
+    </InPageNavProvider>
+  );
+}
+
+function InPageNavInner({ children }: { children: ReactNode }) {
+  const dispatch = useInPageNavDispatch();
+
+  const observer = useMemo(() => {
+    return new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio >= 1) {
+            dispatch({ type: 'SET_ACTIVE_ITEM', payload: entry.target.id });
+            return;
+          }
+        }
+      },
+      { rootMargin: '10% 0 10% 0' },
+    );
+  }, [dispatch]);
+
+  const { active, items: navItems } = useInPageNavState();
+
+  useEffect(() => {
+    observer.takeRecords().forEach((entry) => {
+      observer.unobserve(entry.target);
+    });
+    navItems.forEach((item) => {
+      observer.observe(item.node);
+    });
+  }, [navItems, observer]);
+
+  useEffect(() => {
+    return function cleanup() {
+      observer.disconnect();
+    };
+  }, [observer]);
+
+  return <div>{children}</div>;
+}
+
+function InPageNavList() {
+  return <></>;
+}
+
+export function NavHeading({ children, id, label, level }: NavHeadingProps) {
+  const dispatch = useInPageNavDispatch();
+
+  const ref = useCallback(
+    (node: HTMLHeadingElement | null) => {
+      if (!node) {
+        dispatch({ type: 'DEREGISTER_NAV_ITEM', payload: id });
+      } else {
+        dispatch({
+          type: 'REGISTER_NAV_ITEM',
+          payload: { id, label: label ?? children, node },
+        });
+      }
+    },
+    [children, dispatch, id, label],
+  );
+
+  switch (level) {
+    case 2:
+      return (
+        <h2 id={id} ref={ref}>
+          {children}
+        </h2>
+      );
+    case 3:
+      return (
+        <h3 id={id} ref={ref}>
+          {children}
+        </h3>
+      );
+    case 4:
+      return (
+        <h4 id={id} ref={ref}>
+          {children}
+        </h4>
+      );
+    case 5:
+      return (
+        <h5 id={id} ref={ref}>
+          {children}
+        </h5>
+      );
+    case 6:
+      return (
+        <h6 id={id} ref={ref}>
+          {children}
+        </h6>
+      );
+    default:
+      return (
+        <h2 id={id} ref={ref}>
+          {children}
+        </h2>
+      );
+  }
+}
+
+/*
+## Types
+*/
+
+type Action =
+  | {
+      type: 'REGISTER_NAV_ITEM';
+      payload: InPageNavItem;
+    }
+  | {
+      type: 'SET_ACTIVE_ITEM';
+      payload: string;
+    }
+  | {
+      type: 'DEREGISTER_NAV_ITEM';
+      payload: string;
+    };
+
+type InPageNavItem = {
+  id: string;
+  label: ReactNode;
+  node: HTMLHeadingElement;
+};
+
+type NavHeadingProps = {
+  children: ReactNode;
+  id: string;
+  label?: ReactNode;
+  level: 2 | 3 | 4 | 5 | 6;
+};
+
+type State = {
+  active: string;
+  items: Array<InPageNavItem>;
+};

--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useContext,
   useMemo,
   useState,
@@ -47,8 +46,8 @@ function InPageNavProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const observe = useCallback(
-    (item: InPageNavItem) => {
-      observer.observe(item.node);
+    (item: InPageNavItem, node: HTMLDivElement) => {
+      observer.observe(node);
       setNavItems((prev) => [...prev, item]);
     },
     [observer],
@@ -184,7 +183,7 @@ export function InPageNavAnchor({
       if (!node) {
         unobserve(id);
       } else {
-        observe({ id, label, node, subItem });
+        observe({ id, label, subItem }, node);
       }
     },
     [id, label, observe, unobserve, subItem],
@@ -218,7 +217,6 @@ export function NumberedInPageNavLabel({
 type InPageNavItem = {
   id: string;
   label: ReactNode;
-  node: HTMLDivElement;
   subItem: boolean;
 };
 
@@ -230,7 +228,7 @@ type InPageNavAnchorProps = {
 };
 
 type ObserverDispatch = {
-  observe: (item: InPageNavItem) => void;
+  observe: (item: InPageNavItem, node: HTMLDivElement) => void;
   unobserve: (itemId: string) => void;
 };
 

--- a/app/client/src/components/page.tsx
+++ b/app/client/src/components/page.tsx
@@ -55,11 +55,11 @@ export function Page({ children }: PageProps) {
             </a>
           </div>
         </div>
-      </div>
 
-      <InPageNavLayout>
-        <article className="article">{children}</article>
-      </InPageNavLayout>
+        <InPageNavLayout>
+          <article className="article">{children}</article>
+        </InPageNavLayout>
+      </div>
 
       <div className="l-page__footer">
         <div className="l-constrain">

--- a/app/client/src/components/page.tsx
+++ b/app/client/src/components/page.tsx
@@ -21,9 +21,9 @@ export function Page({ children }: PageProps) {
       <div className="l-constrain">
         <div className="l-page__header">
           <div className="l-page__header-first usa-logo margin-top-0">
-            <h1 className="web-area-title usa-logo__text">
+            <div className="web-area-title usa-logo__text">
               <NavLink to="/">Expert Query</NavLink>
-            </h1>
+            </div>
           </div>
           <div className="l-page__header-last grid-row">
             <a

--- a/app/client/src/components/page.tsx
+++ b/app/client/src/components/page.tsx
@@ -1,7 +1,10 @@
 import { NavLink } from 'react-router-dom';
-import type { ReactNode } from 'react';
+// components
+import { InPageNavLayout } from 'components/inPageNav';
 // config
 import { serverUrl } from 'config';
+// types
+import type { ReactNode } from 'react';
 
 export default Page;
 
@@ -52,9 +55,11 @@ export function Page({ children }: PageProps) {
             </a>
           </div>
         </div>
-
-        <article className="article">{children}</article>
       </div>
+
+      <InPageNavLayout>
+        <article className="article">{children}</article>
+      </InPageNavLayout>
 
       <div className="l-page__footer">
         <div className="l-constrain">

--- a/app/client/src/components/page.tsx
+++ b/app/client/src/components/page.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 // components
 import { InPageNavLayout } from 'components/inPageNav';
 // config
@@ -13,7 +13,7 @@ type PageProps = {
 };
 
 export function Page({ children }: PageProps) {
-  const location = window.location;
+  const location = useLocation();
   const baseUrl =
     location.hostname === 'localhost'
       ? `${location.protocol}//${location.hostname}:9090`
@@ -24,9 +24,15 @@ export function Page({ children }: PageProps) {
       <div className="l-constrain">
         <div className="l-page__header">
           <div className="l-page__header-first usa-logo margin-top-0">
-            <div className="web-area-title usa-logo__text">
-              <NavLink to="/">Expert Query</NavLink>
-            </div>
+            {location.pathname.includes('/api-documentation') ? (
+              <h1 className="web-area-title usa-logo__text">
+                <NavLink to="/">Expert Query</NavLink>
+              </h1>
+            ) : (
+              <div className="web-area-title usa-logo__text">
+                <NavLink to="/">Expert Query</NavLink>
+              </div>
+            )}
           </div>
           <div className="l-page__header-last grid-row">
             <a

--- a/app/client/src/components/radioButtons.tsx
+++ b/app/client/src/components/radioButtons.tsx
@@ -20,7 +20,7 @@ export function RadioButtons({
   return (
     <fieldset className={`usa-fieldset ${styles.join(' ')}`}>
       {legend && (
-        <legend className="align-items-center display-flex usa-legend">
+        <legend className="align-items-center display-flex margin-top-0 usa-legend">
           {legend}
         </legend>
       )}

--- a/app/client/src/components/stepIndicator.tsx
+++ b/app/client/src/components/stepIndicator.tsx
@@ -6,8 +6,8 @@ export function StepIndicator({
   totalSteps,
 }: StepIndicatorProps) {
   return (
-    <div className="usa-step-indicator__header margin-bottom-1">
-      <h4 className="usa-step-indicator__heading">
+    <div className="usa-step-indicator__header margin-bottom-2">
+      <h2 className="usa-step-indicator__heading line-height-sans-2">
         <span className="usa-step-indicator__heading-counter">
           <span className="usa-sr-only">Step</span>
           <span className="usa-step-indicator__current-step margin-right-05">
@@ -18,7 +18,7 @@ export function StepIndicator({
           </span>{' '}
         </span>
         <span className="usa-step-indicator__heading-text">{children}</span>
-      </h4>
+      </h2>
     </div>
   );
 }

--- a/app/client/src/components/stepIndicator.tsx
+++ b/app/client/src/components/stepIndicator.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+export function StepIndicator({
+  children,
+  currentStep,
+  totalSteps,
+}: StepIndicatorProps) {
+  return (
+    <div className="usa-step-indicator__header margin-bottom-1">
+      <h4 className="usa-step-indicator__heading">
+        <span className="usa-step-indicator__heading-counter">
+          <span className="usa-sr-only">Step</span>
+          <span className="usa-step-indicator__current-step margin-right-05">
+            {currentStep}
+          </span>
+          <span className="usa-step-indicator__total-steps">
+            of {totalSteps}
+          </span>{' '}
+        </span>
+        <span className="usa-step-indicator__heading-text">{children}</span>
+      </h4>
+    </div>
+  );
+}
+
+type StepIndicatorProps = {
+  children: ReactNode;
+  currentStep: number;
+  totalSteps: number;
+};

--- a/app/client/src/components/stepIndicator.tsx
+++ b/app/client/src/components/stepIndicator.tsx
@@ -6,18 +6,20 @@ export function StepIndicator({
   totalSteps,
 }: StepIndicatorProps) {
   return (
-    <div className="usa-step-indicator__header margin-bottom-2">
-      <h2 className="usa-step-indicator__heading line-height-sans-2">
+    <div className="usa-step-indicator__header margin-bottom-2 margin-top-4 tablet:margin-top-8">
+      <h2 className="margin-top-0 usa-step-indicator__heading line-height-sans-2">
         <span className="usa-step-indicator__heading-counter">
           <span className="usa-sr-only">Step</span>
-          <span className="usa-step-indicator__current-step margin-right-05">
+          <span className="font-family-mono usa-step-indicator__current-step margin-right-05">
             {currentStep}
           </span>
           <span className="usa-step-indicator__total-steps">
             of {totalSteps}
           </span>{' '}
         </span>
-        <span className="usa-step-indicator__heading-text">{children}</span>
+        <span className="font-heading-lg usa-step-indicator__heading-text">
+          {children}
+        </span>
       </h2>
     </div>
   );

--- a/app/client/src/routes/apiKeySignup.tsx
+++ b/app/client/src/routes/apiKeySignup.tsx
@@ -40,7 +40,7 @@ export function ApiKeySignup() {
 
   return (
     <div>
-      <h2>API Key Signup</h2>
+      <h1>API Key Signup</h1>
       <p>
         Sign up for an application programming interface (API) key to access and
         use <b>Expert Query</b>'s web services, then explore the web service{' '}

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -247,7 +247,7 @@ export function QueryBuilder() {
     profile,
     filterState,
     format,
-    downloadConfirmationVisible,
+    downloadConfirmationVisible || clearConfirmationVisible,
   );
 
   const { content } = useContentState();

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -129,7 +129,7 @@ export function Home() {
               }
             >
               <StepIndicator currentStep={1} totalSteps={3}>
-                Data Profile
+                Pick a Data Profile
               </StepIndicator>
             </InPageNavAnchor>
             <Select
@@ -144,6 +144,11 @@ export function Home() {
               options={staticOptions.dataProfile}
               placeholder="Select a data profile..."
               styles={{
+                container: (baseStyles) => ({
+                  ...baseStyles,
+                  display: 'grid',
+                  gridTemplateColumns: 'minmax(0, 1fr)',
+                }),
                 menu: (baseStyles) => ({
                   ...baseStyles,
                   maxHeight: '75vh',
@@ -1706,7 +1711,7 @@ function matchYear(values: InputValue) {
   return matchDate(values, true);
 }
 
-// Parse parameters provided in the URL hash into a JSON object
+// Parse parameters provided in the URL search into a JSON object
 function parseInitialParams(
   profile: Profile,
 ): [FilterQueryData, ParameterErrors] {

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1125,27 +1125,8 @@ function useQueryParams({
   if (profile && parametersLoaded && filterState !== prevFilterState) {
     setPrevFilterState(filterState);
     // Get selected parameters, including multiselectable fields
-    const newFilterQueryParams: FilterQueryData = {};
-    Object.entries(filterState).forEach(
-      ([field, value]: [string, FilterFieldState[keyof FilterFieldState]]) => {
-        if (isEmpty(value)) return;
-
-        // Extract 'value' field from Option types
-        const flattenedValue = getInputValue(value);
-        const formattedValue =
-          (dateFields as string[]).includes(field) &&
-          typeof flattenedValue === 'string'
-            ? fromIsoDateString(flattenedValue)
-            : flattenedValue;
-
-        if (formattedValue && isProfileField(field, profile)) {
-          newFilterQueryParams[field as FilterField] = formattedValue;
-        }
-      },
-    );
-
     setParameters({
-      filters: newFilterQueryParams,
+      filters: buildFilterData(filterState, profile),
       options: { format },
       columns: Array.from(profiles[profile].columns),
     });
@@ -1187,6 +1168,28 @@ function addDomainAliases(values: DomainOptions): Required<DomainOptions> {
     associatedActionType: values.actionType,
     pollutant: values.parameterName,
   };
+}
+
+function buildFilterData(filterState: FilterFieldState, profile: Profile) {
+  const newFilterQueryParams: FilterQueryData = {};
+  Object.entries(filterState).forEach(
+    ([field, value]: [string, FilterFieldState[keyof FilterFieldState]]) => {
+      if (isEmpty(value)) return;
+
+      // Extract 'value' field from Option types
+      const flattenedValue = getInputValue(value);
+      const formattedValue =
+        (dateFields as string[]).includes(field) &&
+        typeof flattenedValue === 'string'
+          ? fromIsoDateString(flattenedValue)
+          : flattenedValue;
+
+      if (formattedValue && isProfileField(field, profile)) {
+        newFilterQueryParams[field as FilterField] = formattedValue;
+      }
+    },
+  );
+  return newFilterQueryParams;
 }
 
 // Converts a JSON object into a parameter string

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -16,6 +16,7 @@ import { Checkbox } from 'components/checkbox';
 import { Checkboxes } from 'components/checkboxes';
 import { CopyBox } from 'components/copyBox';
 import { InfoTooltip } from 'components/infoTooltip';
+import { InPageNav, NavHeading } from 'components/inPageNav';
 import { Loading } from 'components/loading';
 import { DownloadModal } from 'components/downloadModal';
 import { ClearSearchModal } from 'components/clearSearchModal';
@@ -121,8 +122,8 @@ export function Home() {
           <ParameterErrorAlert parameters={queryParamErrors} />
           <Intro />
           {staticOptions && (
-            <>
-              <h2>Data Profile</h2>
+            <InPageNav>
+              <NavHeading id="select-data-profile">Data Profile</NavHeading>
               <Select
                 id="select-data-profile"
                 classNames={{
@@ -166,7 +167,7 @@ export function Home() {
                   />
                 </>
               )}
-            </>
+            </InPageNav>
           )}
         </div>
       </>
@@ -301,14 +302,18 @@ export function QueryBuilder() {
               API Documentation
             </a>{' '}
             page to learn more.
-            <h3>Current Query</h3>
+            <NavHeading id="current-query" level={3}>
+              Current Query
+            </NavHeading>
             <CopyBox
               testId="current-query-copy-box-container"
               text={`${window.location.origin}${
                 window.location.pathname
               }?${buildUrlQueryString(queryParams.filters)}`}
             />
-            <h3>{profiles[profile].label} API Query</h3>
+            <NavHeading id="webservice-query" level={3}>
+              {profiles[profile].label} API Query
+            </NavHeading>
             <CopyBox
               testId="api-query-copy-box-container"
               lengthExceededMessage="The GET request for this query exceeds the maximum URL character length. Please use a POST request instead (see the cURL query below)."

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -247,6 +247,11 @@ export function QueryBuilder() {
       )}
       {profile && (
         <div>
+          <div className="margin-top-2">
+            <Button onClick={openClearConfirmation} color="white">
+              Clear Search
+            </Button>
+          </div>
           <InPageNavAnchor
             id="apply-filters"
             label={
@@ -259,11 +264,6 @@ export function QueryBuilder() {
               Apply Filters
             </StepIndicator>
           </InPageNavAnchor>
-          <div className="display-flex width-full flex-justify-center">
-            <Button onClick={openClearConfirmation} color="white">
-              Clear Search
-            </Button>
-          </div>
           <FilterGroups
             apiKey={apiKey}
             apiUrl={apiUrl}
@@ -334,14 +334,16 @@ export function QueryBuilder() {
               API Documentation
             </a>{' '}
             page to learn more.
-            <h3>Current Query</h3>
+            <h4 className="text-primary">Current Query</h4>
             <CopyBox
               testId="current-query-copy-box-container"
               text={`${window.location.origin}${
                 window.location.pathname
               }?${buildUrlQueryString(queryParams.filters)}`}
             />
-            <h3>{profiles[profile].label} API Query</h3>
+            <h4 className="text-primary">
+              {profiles[profile].label} API Query
+            </h4>
             <CopyBox
               testId="api-query-copy-box-container"
               lengthExceededMessage="The GET request for this query exceeds the maximum URL character length. Please use a POST request instead (see the cURL query below)."
@@ -354,7 +356,7 @@ export function QueryBuilder() {
                 queryParams.columns,
               )}&api_key=<YOUR_API_KEY>`}
             />
-            <h3>cURL</h3>
+            <h4 className="text-primary">cURL</h4>
             <CopyBox
               testId="curl-copy-box-container"
               text={`curl -X POST --json "${JSON.stringify(
@@ -548,7 +550,9 @@ function FilterGroups(props: FilterGroupsProps) {
           >
             <hr />
             <InPageNavAnchor id={id} label={label} subItem>
-              <h3 className="text-primary">{label}</h3>
+              <h3 className="font-heading-md margin-bottom-0 text-primary">
+                {label}
+              </h3>
             </InPageNavAnchor>
             <FilterFields
               {...props}

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1082,6 +1082,15 @@ function useQueryParams({
 }) {
   const { getSignal } = useAbort();
 
+  const parameters: QueryData = useMemo(() => {
+    if (!profile) return { columns: [], filters: {}, options: {} };
+    return {
+      columns: Array.from(profiles[profile].columns),
+      options: { format },
+      filters: buildFilterData(filterState, profile),
+    };
+  }, [filterState, format, profile]);
+
   const [parameterErrors, setParameterErrors] =
     useState<ParameterErrors | null>(null);
   const [parametersLoaded, setParametersLoaded] = useState(false);
@@ -1103,34 +1112,17 @@ function useQueryParams({
       });
   }
 
-  // Track non-empty values relevant to the current profile
-  const [parameters, setParameters] = useState<QueryData>({
-    columns: [],
-    filters: {},
-    options: {},
-  });
-
   const navigate = useNavigate();
 
+  // Update URL when inputs change
   useEffect(() => {
+    if (!parametersLoaded) return;
+
     navigate(
       '?' + buildUrlQueryString(parameters.filters) + window.location.hash,
       { replace: true },
     );
-  }, [navigate, parameters]);
-
-  // Update URL when inputs change
-  const [prevFilterState, setPrevFilterState] = useState(filterState);
-
-  if (profile && parametersLoaded && filterState !== prevFilterState) {
-    setPrevFilterState(filterState);
-    // Get selected parameters, including multiselectable fields
-    setParameters({
-      filters: buildFilterData(filterState, profile),
-      options: { format },
-      columns: Array.from(profiles[profile].columns),
-    });
-  }
+  }, [navigate, parameters, parametersLoaded]);
 
   return { queryParams: parameters, queryParamErrors: parameterErrors };
 }

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -10,19 +10,18 @@ import {
 import Select from 'react-select';
 import { ReactComponent as Download } from '@uswds/uswds/img/usa-icons/file_download.svg';
 // components
-import { Accordion, AccordionItem } from 'components/accordion';
+import { AccordionItem } from 'components/accordion';
 import { Alert } from 'components/alert';
-import { Checkbox } from 'components/checkbox';
 import { Checkboxes } from 'components/checkboxes';
 import { CopyBox } from 'components/copyBox';
 import { InfoTooltip } from 'components/infoTooltip';
-import { InPageNav, NavHeading } from 'components/inPageNav';
+import { InPageNavAnchor, NumberedInPageNavLabel } from 'components/inPageNav';
 import { Loading } from 'components/loading';
 import { DownloadModal } from 'components/downloadModal';
 import { ClearSearchModal } from 'components/clearSearchModal';
 import { RadioButtons } from 'components/radioButtons';
 import { SourceSelect } from 'components/sourceSelect';
-import { Summary } from 'components/summary';
+import { StepIndicator } from 'components/stepIndicator';
 import { Button } from 'components/button';
 // contexts
 import { useContentState } from 'contexts/content';
@@ -115,62 +114,70 @@ export function Home() {
 
   if (content.status === 'success') {
     return (
-      <>
-        <div>
-          <h1>Query ATTAINS Data</h1>
-          <hr />
-          <ParameterErrorAlert parameters={queryParamErrors} />
-          <Intro />
-          {staticOptions && (
-            <InPageNav>
-              <NavHeading id="select-data-profile">Data Profile</NavHeading>
-              <Select
-                id="select-data-profile"
-                classNames={{
-                  option: () => 'border-bottom border-base-lighter',
-                }}
-                instanceId="instance-select-data-profile"
-                aria-label="Select a data profile"
-                formatOptionLabel={formatProfileOptionLabel}
-                onChange={handleProfileChange}
-                options={staticOptions.dataProfile}
-                placeholder="Select a data profile..."
-                styles={{
-                  menu: (baseStyles) => ({
-                    ...baseStyles,
-                    maxHeight: '75vh',
-                  }),
-                  menuList: (baseStyles) => ({
-                    ...baseStyles,
-                    maxHeight: '75vh',
-                  }),
-                }}
-                value={profileOption}
-              />
+      <div>
+        <h1>Query ATTAINS Data</h1>
+        <hr />
+        <ParameterErrorAlert parameters={queryParamErrors} />
+        {staticOptions && (
+          <>
+            <InPageNavAnchor
+              id="data-profile"
+              label={
+                <NumberedInPageNavLabel number={1}>
+                  Pick a Data Profile
+                </NumberedInPageNavLabel>
+              }
+            >
+              <StepIndicator currentStep={1} totalSteps={3}>
+                Data Profile
+              </StepIndicator>
+            </InPageNavAnchor>
+            <Select
+              id="select-data-profile"
+              classNames={{
+                option: () => 'border-bottom border-base-lighter',
+              }}
+              instanceId="instance-select-data-profile"
+              aria-label="Select a data profile"
+              formatOptionLabel={formatProfileOptionLabel}
+              onChange={handleProfileChange}
+              options={staticOptions.dataProfile}
+              placeholder="Select a data profile..."
+              styles={{
+                menu: (baseStyles) => ({
+                  ...baseStyles,
+                  maxHeight: '75vh',
+                }),
+                menuList: (baseStyles) => ({
+                  ...baseStyles,
+                  maxHeight: '75vh',
+                }),
+              }}
+              value={profileOption}
+            />
 
-              {profile && (
-                <>
-                  <Outlet
-                    context={{
-                      filterHandlers,
-                      filterState,
-                      format,
-                      formatHandler,
-                      profile,
-                      queryParams,
-                      queryUrl: apiUrl,
-                      resetFilters,
-                      sourceHandlers,
-                      sourceState,
-                      staticOptions,
-                    }}
-                  />
-                </>
-              )}
-            </InPageNav>
-          )}
-        </div>
-      </>
+            {profile && (
+              <>
+                <Outlet
+                  context={{
+                    filterHandlers,
+                    filterState,
+                    format,
+                    formatHandler,
+                    profile,
+                    queryParams,
+                    queryUrl: apiUrl,
+                    resetFilters,
+                    sourceHandlers,
+                    sourceState,
+                    staticOptions,
+                  }}
+                />
+              </>
+            )}
+          </>
+        )}
+      </div>
     );
   }
 
@@ -234,63 +241,83 @@ export function QueryBuilder() {
         />
       )}
       {profile && (
-        <Accordion>
-          <AccordionItem heading="Filters" initialExpand>
-            <div className="display-flex width-full flex-justify-center">
-              <Button onClick={openClearConfirmation} color="white">
-                Clear Search
-              </Button>
-            </div>
-            <FilterGroups
-              apiKey={apiKey}
-              apiUrl={apiUrl}
-              filterHandlers={filterHandlers}
-              filterState={filterState}
-              profile={profile}
-              queryParams={queryParams}
-              sourceHandlers={sourceHandlers}
-              sourceState={sourceState}
-              staticOptions={staticOptions}
-            />
-          </AccordionItem>
+        <div>
+          <InPageNavAnchor
+            id="apply-filters"
+            label={
+              <NumberedInPageNavLabel number={2}>
+                Apply Filters
+              </NumberedInPageNavLabel>
+            }
+          >
+            <StepIndicator currentStep={2} totalSteps={3}>
+              Apply Filters
+            </StepIndicator>
+          </InPageNavAnchor>
+          <div className="display-flex width-full flex-justify-center">
+            <Button onClick={openClearConfirmation} color="white">
+              Clear Search
+            </Button>
+          </div>
+          <FilterGroups
+            apiKey={apiKey}
+            apiUrl={apiUrl}
+            filterHandlers={filterHandlers}
+            filterState={filterState}
+            profile={profile}
+            queryParams={queryParams}
+            sourceHandlers={sourceHandlers}
+            sourceState={sourceState}
+            staticOptions={staticOptions}
+          />
 
-          <AccordionItem heading="Download the Data" initialExpand>
-            <RadioButtons
-              legend={
-                <>
-                  <b className="margin-right-05">File Format</b>
-                  <InfoTooltip text="Choose a file format for the result set." />
-                </>
-              }
-              onChange={formatHandler}
-              options={staticOptions.format}
-              selected={format}
-              styles={['margin-bottom-2']}
+          <InPageNavAnchor
+            id="download"
+            label={
+              <NumberedInPageNavLabel number={3}>
+                Download the Data
+              </NumberedInPageNavLabel>
+            }
+          >
+            <StepIndicator currentStep={3} totalSteps={3}>
+              Download the Data
+            </StepIndicator>
+          </InPageNavAnchor>
+          <RadioButtons
+            legend={
+              <>
+                <b className="margin-right-05">File Format</b>
+                <InfoTooltip text="Choose a file format for the result set." />
+              </>
+            }
+            onChange={formatHandler}
+            options={staticOptions.format}
+            selected={format}
+            styles={['margin-bottom-2']}
+          />
+          <button
+            className="display-flex flex-justify-center margin-bottom-1 usa-button"
+            onClick={openDownloadConfirmation}
+            type="button"
+          >
+            <Download
+              aria-hidden="true"
+              className="height-205 margin-right-1 usa-icon width-205"
             />
-            <button
-              className="display-flex flex-justify-center margin-bottom-1 usa-button"
-              onClick={openDownloadConfirmation}
-              type="button"
-            >
-              <Download
-                aria-hidden="true"
-                className="height-205 margin-right-1 usa-icon width-205"
-              />
-              <span className="margin-y-auto">Download</span>
-            </button>
-            {downloadStatus === 'success' && (
-              <Alert type="success">
-                Query executed successfully, please check your downloads folder
-                for the output file.
-              </Alert>
-            )}
-            {downloadStatus === 'failure' && (
-              <Alert type="error">
-                An error occurred while executing the current query, please try
-                again later.
-              </Alert>
-            )}
-          </AccordionItem>
+            <span className="margin-y-auto">Download</span>
+          </button>
+          {downloadStatus === 'success' && (
+            <Alert type="success">
+              Query executed successfully, please check your downloads folder
+              for the output file.
+            </Alert>
+          )}
+          {downloadStatus === 'failure' && (
+            <Alert type="error">
+              An error occurred while executing the current query, please try
+              again later.
+            </Alert>
+          )}
 
           <AccordionItem heading="Advanced Queries">
             Visit our{' '}
@@ -302,18 +329,14 @@ export function QueryBuilder() {
               API Documentation
             </a>{' '}
             page to learn more.
-            <NavHeading id="current-query" level={3}>
-              Current Query
-            </NavHeading>
+            <h3>Current Query</h3>
             <CopyBox
               testId="current-query-copy-box-container"
               text={`${window.location.origin}${
                 window.location.pathname
               }?${buildUrlQueryString(queryParams.filters)}`}
             />
-            <NavHeading id="webservice-query" level={3}>
-              {profiles[profile].label} API Query
-            </NavHeading>
+            <h3>{profiles[profile].label} API Query</h3>
             <CopyBox
               testId="api-query-copy-box-container"
               lengthExceededMessage="The GET request for this query exceeds the maximum URL character length. Please use a POST request instead (see the cURL query below)."
@@ -336,7 +359,7 @@ export function QueryBuilder() {
               } -H "X-Api-Key: <YOUR_API_KEY>"`}
             />
           </AccordionItem>
-        </Accordion>
+        </div>
       )}
     </>
   );
@@ -510,66 +533,28 @@ function FilterGroups(props: FilterGroupsProps) {
 
   return (
     <>
-      {groupedFields.map((group, i) => (
-        <section
-          className={`margin-top-${i === 0 ? '2' : '6'}`}
-          key={group.key}
-        >
-          <hr />
-          <h3 className="text-primary">{filterGroupLabels[group.key]}</h3>
-          <FilterFields
-            {...props}
-            fields={group.fields as Array<(typeof filterFieldsConfig)[number]>}
-          />
-        </section>
-      ))}
+      {groupedFields.map((group, i) => {
+        const label = filterGroupLabels[group.key];
+        const id = camelToKebab(group.key);
+        return (
+          <section
+            className={`margin-top-${i === 0 ? '2' : '4'}`}
+            key={group.key}
+          >
+            <hr />
+            <InPageNavAnchor id={id} label={label} subItem>
+              <h3 className="text-primary">{label}</h3>
+            </InPageNavAnchor>
+            <FilterFields
+              {...props}
+              fields={
+                group.fields as Array<(typeof filterFieldsConfig)[number]>
+              }
+            />
+          </section>
+        );
+      })}
     </>
-  );
-}
-
-function Intro() {
-  const [visible, setVisible] = useState(
-    !!JSON.parse(getLocalStorageItem('showIntro') ?? 'true'),
-  );
-
-  const closeIntro = useCallback(() => setVisible(false), []);
-
-  const [dontShowAgain, setDontShowAgain] = useState<boolean | null>(null);
-
-  const toggleDontShowAgain = useCallback(
-    () => setDontShowAgain(!dontShowAgain),
-    [dontShowAgain],
-  );
-
-  useEffect(() => {
-    if (dontShowAgain === null) return;
-    setLocalStorageItem('showIntro', JSON.stringify(!dontShowAgain));
-  }, [dontShowAgain]);
-
-  if (!visible) return null;
-
-  return (
-    <Summary heading="How to Use This Application">
-      <p>
-        Select a data profile, then build a query by selecting options from the
-        input fields.
-      </p>
-      <div className="display-flex flex-justify flex-wrap">
-        <Checkbox
-          checked={dontShowAgain ?? false}
-          label="Don't show again on this computer"
-          onChange={toggleDontShowAgain}
-          styles={['margin-right-1 margin-y-auto']}
-        />
-        <button
-          className="margin-top-2 usa-button"
-          onClick={closeIntro}
-          type="button"
-        >
-          Close Intro
-        </button>
-      </div>
-    </Summary>
   );
 }
 
@@ -1044,7 +1029,7 @@ function useQueryParams({
     options: {},
   });
 
-  const [_searchParams, setSearchParams] = useSearchParams();
+  const [, setSearchParams] = useSearchParams();
 
   // Update URL when inputs change
   useEffect(() => {
@@ -1070,9 +1055,7 @@ function useQueryParams({
       },
     );
 
-    if (Object.keys(newFilterQueryParams).length) {
-      setSearchParams(newFilterQueryParams, { replace: true });
-    } else removeHash();
+    setSearchParams(newFilterQueryParams, { replace: true });
 
     setParameters({
       filters: newFilterQueryParams,
@@ -1168,6 +1151,17 @@ function buildUrlQueryString(
   return encodeURI(
     paramsList.reduce((a, b) => a + `&${b[0]}=${b[1]}`, '').replace('&', ''),
   ); // trim the leading ampersand
+}
+
+function camelToKebab(camel: string) {
+  return camel
+    .split('')
+    .map((letter) => {
+      return letter === letter.toUpperCase()
+        ? '-' + letter.toLowerCase()
+        : letter;
+    })
+    .join('');
 }
 
 // Returns a boolean, specifying if a value is found in the
@@ -1461,10 +1455,6 @@ function getInputValue(input: Option | ReadonlyArray<Option> | string) {
   }
   if (isOption(input)) return input.value;
   return input;
-}
-
-function getLocalStorageItem(item: string) {
-  return localStorage.getItem(item) ?? null;
 }
 
 function getMultiOptionFields(fields: typeof allFieldsConfig) {
@@ -1761,50 +1751,6 @@ function parseInitialParams(
   );
 
   return [params, paramErrors];
-}
-
-function removeHash() {
-  const location = window.location;
-  if ('pushState' in window.history)
-    window.history.replaceState(null, '', location.pathname);
-  else {
-    // Prevent scrolling by storing the page's current scroll offset
-    const scrollTop = document.body.scrollTop;
-    const scrollLeft = document.body.scrollLeft;
-
-    location.hash = '';
-
-    // Restore the scroll offset, should be flicker free
-    document.body.scrollTop = scrollTop;
-    document.body.scrollLeft = scrollLeft;
-  }
-}
-
-function setLocalStorageItem(item: string, value: string) {
-  storageAvailable() && localStorage.setItem(item, value);
-}
-
-function storageAvailable(
-  storageType: 'localStorage' | 'sessionStorage' = 'localStorage',
-) {
-  const storage: Storage = window[storageType];
-  try {
-    const x = '__storage_test__';
-    storage.setItem(x, x);
-    storage.removeItem(x);
-    return true;
-  } catch (e) {
-    return (
-      e instanceof DOMException &&
-      // everything except Firefox
-      (e.name === 'QuotaExceededError' ||
-        // Firefox
-        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
-      // acknowledge QuotaExceededError only if there's something already stored
-      storage &&
-      storage.length !== 0
-    );
-  }
 }
 
 /*

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -154,6 +154,11 @@ export function Home() {
                 Pick a Data Profile
               </StepIndicator>
             </InPageNavAnchor>
+            <p>
+              Data are grouped into profiles according to the type of data they
+              describe. Select a data profile to determine the set of filterable
+              elements.
+            </p>
             <Select
               id="select-data-profile"
               classNames={{
@@ -296,6 +301,10 @@ export function QueryBuilder() {
               Apply Filters
             </StepIndicator>
           </InPageNavAnchor>
+          <p>
+            Select options from the fields below to apply filters to the query.
+            The options of some fields are filtered by previous selections.
+          </p>
           <FilterGroups
             apiKey={apiKey}
             apiUrl={apiUrl}
@@ -320,6 +329,10 @@ export function QueryBuilder() {
               Download the Data
             </StepIndicator>
           </InPageNavAnchor>
+          <p>
+            Choose an output file format for the result set, then click the
+            download button to proceed.
+          </p>
           <RadioButtons
             legend={
               <>

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -25,7 +25,7 @@ export function NationalDownloads() {
   return (
     <>
       <div>
-        <h2>National Downloads</h2>
+        <h1>National Downloads</h1>
         <hr />
         <Summary heading="Description">
           <p>
@@ -60,7 +60,7 @@ function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
   if (status === 'success')
     return (
       <section className="margin-top-6" id="attains">
-        <h3 className="text-primary">ATTAINS Data</h3>
+        <h2 className="text-primary">ATTAINS Data</h2>
         Go to the <Link to="/attains">ATTAINS Query</Link> page.
         <table className="margin-x-auto usa-table usa-table--stacked width-full">
           <thead>

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -62,9 +62,7 @@ type FetchSuccessState<Type> = {
 export type Option = {
   description?: ReactNode;
   label: ReactNode;
-  value: Primitive;
+  value: string;
 };
-
-export type Primitive = string | number | boolean;
 
 export type Status = 'idle' | 'pending' | 'failure' | 'success';

--- a/app/client/src/types/react-router-dom.d.ts
+++ b/app/client/src/types/react-router-dom.d.ts
@@ -1,0 +1,13 @@
+import * as reactRouterDom from 'react-router-dom';
+declare module 'react-router-dom' {
+  declare interface Location {
+    hash: string;
+    host: string;
+    hostname: string;
+    href: string;
+    origin: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+  }
+}


### PR DESCRIPTION
## Related Issues:

- [EQ-268](https://jira.epa.gov/browse/EQ-268)
- [EQ-274](https://jira.epa.gov/browse/EQ-274)
- [EQ-281](https://jira.epa.gov/browse/EQ-281)

## Main Changes:

- Added an in-page navigation component, which allows users to jump to different predetermined locations on the page. This is based on the same [USWDS component](https://designsystem.digital.gov/components/in-page-navigation/), but with custom state management, as the JavaScript side of the USWDS component isn't compatible with React. This has the added benefit of allowing us to style the labels as we please.
- Removed the introduction message box.
- Styled the section headings of the main page as step indicators, and added short descriptions for each. Additionally, the sections are no longer accordions (except for the Advanced Queries section).
- Removed the timeout from the download success/error messages, and implemented logic to dismiss them when there are other state changes.
  - I didn't add the close (x) to the message, because the messages are dismissed easily. **Should this be added?**
- Adjusted some spacing.
- Moved the "Clear Search" button just below the data profile select input. To avoid confusion, I also updated the behavior so that this clears the profile selection, which I think helps clarify that fields were cleared.
- Removed some unnecessary effects.

## Steps To Test:

1. Confirm that the in-page navigation only appears on the main page.
2. Test the behavior of the navigation, and verify that it updates when profiles are switched.
3. Test the download success message. It should dismiss when a new profile is selected, a filter is updated, the file format is changed, or the download button is clicked again.