### PR TITLE
Feature/293 always show count

### DIFF
--- a/app/client/src/components/downloadModal.tsx
+++ b/app/client/src/components/downloadModal.tsx
@@ -38,10 +38,11 @@ export function DownloadModal<D extends PostData>({
 
   const focusRef = useRef<HTMLButtonElement>(null);
 
-  const [count, setCount] = useState<FetchState<number | null>>({
+  const [count, setCount] = useState<FetchState<number>>({
     status: 'pending',
     data: null,
   });
+  const [sizeExceeded, setSizeExceeded] = useState(false);
 
   // Get the row count for the current query
   useEffect(() => {
@@ -53,8 +54,9 @@ export function DownloadModal<D extends PostData>({
       .then((res) => {
         setCount({
           status: 'success',
-          data: 'count' in res ? res.count : null,
+          data: res.count,
         });
+        setSizeExceeded(res.sizeExceeded);
       })
       .catch((err) => {
         if (isAbort(err)) return;
@@ -137,72 +139,70 @@ export function DownloadModal<D extends PostData>({
           )}
           {count.status === 'success' && (
             <>
-              {count.data === null ? (
-                <Alert type="warning">
-                  <p>The current query exceeds the maximum query size.</p>{' '}
-                  <p>
-                    Please refine the search, or visit the{' '}
-                    <a
-                      href={`${serverUrl}/national-downloads${
-                        dataId ? '#' + dataId : ''
-                      }`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      National Downloads
-                    </a>{' '}
-                    page to download a compressed dataset.
-                  </p>
-                </Alert>
-              ) : (
-                <>
-                  <div className="usa-prose">
+              <div className="usa-prose">
+                <p>
+                  Your query will return{' '}
+                  <strong data-testid="downloadfile-length">
+                    {count.data.toLocaleString()}
+                  </strong>{' '}
+                  rows.
+                </p>
+                {!sizeExceeded && <p>Click continue to download the data.</p>}
+              </div>
+              <div className="usa-modal__footer">
+                {sizeExceeded ? (
+                  <Alert type="warning">
+                    <p>The current query exceeds the maximum query size.</p>{' '}
                     <p>
-                      Your query will return{' '}
-                      <strong data-testid="downloadfile-length">
-                        {count.data.toLocaleString()}
-                      </strong>{' '}
-                      rows.
+                      Please refine the search, or visit the{' '}
+                      <a
+                        href={`${serverUrl}/national-downloads${
+                          dataId ? '#' + dataId : ''
+                        }`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        National Downloads
+                      </a>{' '}
+                      page to download a compressed dataset.
                     </p>
-                    <p>Click continue to download the data.</p>
-                  </div>
-                  <div className="usa-modal__footer">
-                    <ul className="flex-justify-center usa-button-group">
-                      <li className="usa-button-group__item mobile-lg:margin-right-5 mobile-lg:margin-y-auto">
+                  </Alert>
+                ) : (
+                  <ul className="flex-justify-center usa-button-group">
+                    <li className="usa-button-group__item mobile-lg:margin-right-5 mobile-lg:margin-y-auto">
+                      <button
+                        type="button"
+                        className="height-5 usa-button"
+                        onClick={closeModal}
+                        ref={focusRef}
+                      >
+                        Cancel
+                      </button>
+                    </li>
+                    <li className="usa-button-group__item mobile-lg:margin-y-auto">
+                      {downloadStatus === 'pending' ? (
                         <button
+                          className="display-flex flex-justify-center height-5 usa-button hover:bg-primary mobile-lg:width-15"
+                          onClick={undefined}
+                          style={{ cursor: 'initial' }}
                           type="button"
-                          className="height-5 usa-button"
-                          onClick={closeModal}
-                          ref={focusRef}
                         >
-                          Cancel
+                          Working <LoadingButtonIcon />
                         </button>
-                      </li>
-                      <li className="usa-button-group__item mobile-lg:margin-y-auto">
-                        {downloadStatus === 'pending' ? (
-                          <button
-                            className="display-flex flex-justify-center height-5 usa-button hover:bg-primary mobile-lg:width-15"
-                            onClick={undefined}
-                            style={{ cursor: 'initial' }}
-                            type="button"
-                          >
-                            Working <LoadingButtonIcon />
-                          </button>
-                        ) : (
-                          <button
-                            className="height-5 usa-button mobile-lg:width-15"
-                            disabled={count.data === 0}
-                            onClick={executeQuery}
-                            type="button"
-                          >
-                            Continue
-                          </button>
-                        )}
-                      </li>
-                    </ul>
-                  </div>
-                </>
-              )}
+                      ) : (
+                        <button
+                          className="height-5 usa-button mobile-lg:width-15"
+                          disabled={count.data === 0}
+                          onClick={executeQuery}
+                          type="button"
+                        >
+                          Continue
+                        </button>
+                      )}
+                    </li>
+                  </ul>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/app/server/app/content/swagger/api-public.json
+++ b/app/server/app/content/swagger/api-public.json
@@ -4979,25 +4979,22 @@
         }
       },
       "QueryCountSuccess": {
-        "description": "The query evaluated successfully. The response contains the total count of the query or a message indicating that the maximum query size was exceeded.",
+        "description": "The query evaluated successfully. The response contains the total count of the query and a flag indicating if the query would exceed the maximum size allowed by the server.",
         "content": {
           "application/json": {
             "schema": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "integer",
-                      "example": 148220
-                    }
-                  },
-                  "required": ["count"]
+              "type": "object",
+              "properties": {
+                "count": {
+                  "type": "integer",
+                  "example": 148220
                 },
-                {
-                  "$ref": "#/components/schemas/QuerySizeExceededMessage"
+                "sizeExceeded": {
+                  "type": "boolean",
+                  "example": false
                 }
-              ]
+              },
+              "required": ["count", "sizeExceeded"]
             }
           }
         }

--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -312,7 +312,6 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
       : null;
 
   // build select statement of the query
-  let selectText = undefined;
   if (!countOnly) {
     // filter down to requested columns, if the user provided that option
     const columnsToReturn = [];
@@ -326,11 +325,11 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
     // build the select query
     const selectColumns =
       columnsToReturn.length > 0 ? columnsToReturn : profile.columns;
-    selectText = selectColumns.map((col) =>
+    const selectText = selectColumns.map((col) =>
       col.name === col.alias ? col.name : `${col.name} AS ${col.alias}`,
     );
+    query.select(selectText).orderBy('objectid', 'asc');
   }
-  query.select(selectText).orderBy('objectid', 'asc');
 
   // build where clause of the query
   profile.columns.forEach((col) => {
@@ -374,7 +373,7 @@ async function executeQuery(profile, req, res) {
     parseCriteria(req, query, profile, queryParams);
 
     // Check that the query doesn't exceed the MAX_QUERY_SIZE.
-    if ((await checkQueryCount(query)) === null) {
+    if ((await query.clone().count().first()).count > maxQuerySize) {
       return res.status(200).json({
         message: `The current query exceeds the maximum query size. Please refine the search, or visit ${process.env.SERVER_URL}/national-downloads to download a compressed dataset`,
       });
@@ -429,27 +428,6 @@ function validateQueryParams(queryParams, profile) {
 }
 
 /**
- * Counts the number of rows returned be a specified
- * query without modifying the query object
- * @param {Object} query KnexJS query object
- * @returns {Object | null} object with 'count' property, or null if limit exceeded
- */
-async function checkQueryCount(query) {
-  const count = await knex
-    .from(
-      query
-        .clone()
-        .limit(maxQuerySize + 1)
-        .as('q'),
-    )
-    .count()
-    .first();
-
-  if (count.count > maxQuerySize) return null;
-  return count.count;
-}
-
-/**
  * Runs a query against the provided profile name and returns the number of records.
  * @param {Object} profile definition of the profile being queried
  * @param {express.Request} req
@@ -468,15 +446,12 @@ function executeQueryCountOnly(profile, req, res) {
 
     parseCriteria(req, query, profile, queryParams, true);
 
-    checkQueryCount(query).then((count) => {
-      if (count === null) {
-        res.status(200).json({
-          message: `The current query exceeds the maximum query size. Please refine the search, or visit ${process.env.SERVER_URL}/national-downloads to download a compressed dataset`,
-        });
-      } else {
-        res.status(200).json({ count });
-      }
-    });
+    query
+      .count()
+      .first()
+      .then(({ count }) => {
+        res.status(200).json({ count, sizeExceeded: count > maxQuerySize });
+      });
   } catch (error) {
     log.error(
       formatLogMsg(


### PR DESCRIPTION
## Related Issues:
* [EQ-293](https://jira.epa.gov/browse/EQ-293)

## Main Changes:
* Returned the "count" endpoints to their original behavior of returning a query's full count, even if it exceeds the maximum size.
* Added a `sizeExceeded` flag to the response, which indicates if the query, if executed, would be denied by the server.
* Updated the download modal so that if the query size is exceeded, the count is shown alongside the link to the National Downloads page.

## Steps To Test:
1. Start the application with the server pointed to the dev database.
2. Navigate to http://localhost:3000/attains/assessments#download, then click download.
3. The count should be shown above an alert that directs to the National Downloads page.
4. Navigate to http://localhost:3000/attains/assessments?state=AK#download, and click download.
5. The count should be shown above the "Cancel" and "Continue" buttons.
6. Click continue, and verify that the query executes successfully.