### PR TITLE
Feature/284 improve health endpoints

### DIFF
--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -710,6 +710,11 @@ async function checkDatabaseHealth(req, res) {
   const metadataObj = populateMetdataObjFromRequest(req);
 
   try {
+    let status = 'UP';
+    function setStatus(newStatus) {
+      if (status === 'UP') status = newStatus;
+    }
+
     // check etl status in db
     let query = knex
       .withSchema('logging')
@@ -717,40 +722,35 @@ async function checkDatabaseHealth(req, res) {
       .select('database')
       .first();
     const statusResults = await query;
-    if (statusResults.database === 'failed') {
-      res.status(200).json({ status: 'FAILED-DB' });
-      return;
-    }
+    if (statusResults.database === 'failed') setStatus('FAILED-DB');
 
     // verify the latest entry in the schema table is active
     query = knex
       .withSchema('logging')
-      .from('etl_schemas')
-      .select('active', 'creation_date')
+      .from('etl_schemas as s')
+      .leftJoin('etl_log as l', 's.id', 'l.schema_id')
+      .select(
+        's.*',
+        'l.start_time',
+        'l.end_time',
+        knex.raw('l.end_time - l.start_time as duration'),
+        'l.load_error',
+      )
       .orderBy('creation_date', 'desc')
       .first();
     const schemaResults = await query;
     if (!schemaResults.active && statusResults.database !== 'running') {
-      res.status(200).json({ status: 'FAILED-SCHEMA' });
-      return;
+      setStatus('FAILED-SCHEMA');
     }
 
-    query = knex
-      .withSchema('logging')
-      .from('etl_schemas')
-      .select('active', 'creation_date')
-      .where('active', true)
-      .orderBy('creation_date', 'desc')
-      .first();
+    query = query.clone();
+    query.where('active', true);
     const activeSchemaResults = await query;
 
     // verify database updated in the last week, with 1 hour buffer
     const timeSinceLastUpdate =
       (Date.now() - activeSchemaResults.creation_date) / (1000 * 60 * 60);
-    if (timeSinceLastUpdate >= 169) {
-      res.status(200).json({ status: 'FAILED-TIME' });
-      return;
-    }
+    if (timeSinceLastUpdate >= 169) setStatus('FAILED-TIME');
 
     // verify a query can be ran against each table in the active db
     for (const profile of Object.values(privateConfig.tableConfig)) {
@@ -761,14 +761,31 @@ async function checkDatabaseHealth(req, res) {
         .limit(1)
         .first();
       const dataResults = await query;
-      if (!dataResults[profile.idColumn]) {
-        res.status(200).json({ status: 'FAILED-QUERY' });
-        return;
-      }
+      if (!dataResults[profile.idColumn]) setStatus('FAILED-QUERY');
+    }
+
+    const output = {
+      status,
+      zLastSuccess: {
+        completed: activeSchemaResults.end_time.toLocaleString(),
+        duration: activeSchemaResults.duration,
+        s3Uuid: activeSchemaResults.s3_julian,
+        schema: activeSchemaResults.schema_name,
+      },
+    };
+
+    // if ids of schemaResults and activeSchemaResults don't match then add zFailed
+    if (schemaResults.id !== activeSchemaResults.id) {
+      output.zFailed = {
+        completed: schemaResults.end_time.toLocaleString(),
+        duration: schemaResults.duration,
+        s3Uuid: schemaResults.s3_julian,
+        schema: schemaResults.schema_name,
+      };
     }
 
     // everything passed
-    res.status(200).json({ status: 'UP' });
+    res.status(200).json(output);
   } catch (error) {
     log.error(formatLogMsg(metadataObj, 'Error!', error));
     res.status(500).send('Error!' + error);


### PR DESCRIPTION
## Related Issues:
* [EQ-284](https://jira.epa.gov/browse/EQ-284)

## Main Changes:
* Added a `schema_id` column to the `etl_log` table. This was done to be able to safely join the `etl_schemas` and `etl_log` tables. 
  * The way it was before the ids of both tables should match up as long as there were no issues. If any issues occurred then the those ids would be out of sync. The above change should prevent that issue.
* Added more output to the `/attains/health/etlDatabase` endpoint. This includes when the etl completed, the s3 folder that was ingested, the db schema name and how long the etl ran. If the etl failed the last time it ran, we show this information for both the failed run and the last successful run. I used the `zLastSuccess` and `zFailed` variable names to ensure that status cake will see the `status` value first in the object.

## Steps To Test:
1. Verify your app and etl are pointed to your local db.
2. Create the `schema_id` column. To do this you can either drop your current database, so the etl gets a fresh start or you can run the query below to add the column and pre-populate the column. The pre-populate query assumes the id in the `etl_log` table matches the id in the `etl_schemas` table.
3. Run the etl
    * Note: If you started with a fresh database run the etl a couple of times.
5. Start the app
6. Navigate to http://localhost:9090/api/attains/health/etlDatabase
7. Verify the output looks correct
8. Manually change the active schema to an older db
9. Repeat steps 5 and 6. The output should include `zLastSuccess` and `zFailed`. 


```
BEGIN;

ALTER TABLE logging.etl_log RENAME CONSTRAINT etl_log_pkey TO etl_log_pkey_old;
ALTER TABLE logging.etl_log RENAME TO etl_log_old;
ALTER SEQUENCE logging.etl_log_id_seq RENAME TO etl_log_id_seq_old;

CREATE TABLE IF NOT EXISTS logging.etl_log
(
    id SERIAL PRIMARY KEY,
	schema_id INTEGER,
    end_time TIMESTAMP,
    load_error VARCHAR,
    start_time TIMESTAMP NOT NULL
);

INSERT INTO logging.etl_log (schema_id, end_time, load_error, start_time)
SELECT id, end_time, load_error, start_time FROM logging.etl_log_old;

DROP TABLE logging.etl_log_old CASCADE;

COMMIT;
```

