### PR TITLE
Feature/303 304 national downloads changes

### DIFF
--- a/app/client/src/components/markdownContent.tsx
+++ b/app/client/src/components/markdownContent.tsx
@@ -21,6 +21,9 @@ export function MarkdownContent({ className, children, components }: Props) {
       children={children}
       remarkPlugins={[remarkGfm]}
       components={{
+        p: ({ node, ...props }) => {
+          return <p className="margin-0">{props.children}</p>
+        },
         ...components,
         a: ({ node, ...props }) => {
           // NOTE: The only attribute GFM allows you to set on hyperlinks is

--- a/app/client/src/components/markdownContent.tsx
+++ b/app/client/src/components/markdownContent.tsx
@@ -1,5 +1,5 @@
-import ReactMarkdown, { Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
+import ReactMarkdown, { Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 type Props = {
   className?: string;
@@ -17,7 +17,7 @@ type Props = {
 export function MarkdownContent({ className, children, components }: Props) {
   return (
     <ReactMarkdown
-      className={className || ""}
+      className={className || ''}
       children={children}
       remarkPlugins={[remarkGfm]}
       components={{
@@ -33,14 +33,13 @@ export function MarkdownContent({ className, children, components }: Props) {
           // the code below will use the title set in the markdown as the
           // rendered anchor link's title attribute.
           const title = node?.properties?.title;
-          const externalLink = title === "external";
           return (
             <a
               {...props}
               className="usa-link"
-              title={title ? (externalLink ? "" : title.toString()) : ""}
-              target={externalLink ? "_blank" : ""}
-              rel={externalLink ? "noopener noreferrer" : ""}
+              title={title?.toString() || ''}
+              target={'_blank'}
+              rel={'noopener noreferrer'}
             >
               {props.children}
             </a>

--- a/app/client/src/components/markdownContent.tsx
+++ b/app/client/src/components/markdownContent.tsx
@@ -21,9 +21,6 @@ export function MarkdownContent({ className, children, components }: Props) {
       children={children}
       remarkPlugins={[remarkGfm]}
       components={{
-        p: ({ node, ...props }) => {
-          return <p className="margin-0">{props.children}</p>
-        },
         ...components,
         a: ({ node, ...props }) => {
           // NOTE: The only attribute GFM allows you to set on hyperlinks is
@@ -36,14 +33,14 @@ export function MarkdownContent({ className, children, components }: Props) {
           // the code below will use the title set in the markdown as the
           // rendered anchor link's title attribute.
           const title = node?.properties?.title;
-          const externalLink = title === "external";
+          const externalLink = title === 'external';
           return (
             <a
               {...props}
               className="usa-link"
-              title={title ? (externalLink ? "" : title.toString()) : ""}
-              target={externalLink ? "_blank" : ""}
-              rel={externalLink ? "noopener noreferrer" : ""}
+              title={title ? (externalLink ? '' : title.toString()) : ''}
+              target={externalLink ? '_blank' : ''}
+              rel={externalLink ? 'noopener noreferrer' : ''}
             >
               {props.children}
             </a>

--- a/app/client/src/components/markdownContent.tsx
+++ b/app/client/src/components/markdownContent.tsx
@@ -33,13 +33,14 @@ export function MarkdownContent({ className, children, components }: Props) {
           // the code below will use the title set in the markdown as the
           // rendered anchor link's title attribute.
           const title = node?.properties?.title;
+          const externalLink = title === "external";
           return (
             <a
               {...props}
               className="usa-link"
-              title={title?.toString() || ''}
-              target={'_blank'}
-              rel={'noopener noreferrer'}
+              title={title ? (externalLink ? "" : title.toString()) : ""}
+              target={externalLink ? "_blank" : ""}
+              rel={externalLink ? "noopener noreferrer" : ""}
             >
               {props.children}
             </a>

--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -87,6 +87,7 @@ export type Content = {
     infoMessages: Array<{
       heading: string;
       content: string;
+      type: 'error' | 'info' | 'success' | 'summary' | 'warning';
     }>;
   };
 };

--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -82,6 +82,13 @@ export type Content = {
       resource: string;
     };
   };
+  nationalDownloads: {
+    heading: string;
+    infoMessages: Array<{
+      heading: string;
+      content: string;
+    }>;
+  };
 };
 
 export type JsonContent = Omit<Content, 'profileConfig'> & {

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -32,18 +32,26 @@ export function NationalDownloads() {
 
   if (status === 'pending') return <Loading />;
 
-  if (status === 'success')
+  if (status === 'success') {
+    const settings = content.data.nationalDownloads;
     return (
       <div>
-        <h1>{content.data.nationalDownloads.heading}</h1>
-        {content.data.nationalDownloads.infoMessages.map((message) => (
-          <Summary heading={message.heading}>
-            <MarkdownContent children={message.content} />
-          </Summary>
-        ))}
+        <h1>{settings.heading}</h1>
+        {settings.infoMessages.map((message) => {
+          return message.type === 'summary' ? (
+            <Summary heading={message.heading}>
+              <MarkdownContent children={message.content} />
+            </Summary>
+          ) : (
+            <Alert type={message.type} heading={message.heading}>
+              <MarkdownContent children={message.content} />
+            </Alert>
+          );
+        })}
         <NationalDownloadsData content={content} />
       </div>
     );
+  }
 
   return null;
 }

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -44,7 +44,12 @@ export function NationalDownloads() {
             </Summary>
           ) : (
             <Alert type={message.type} heading={message.heading}>
-              <MarkdownContent children={message.content} />
+              <MarkdownContent
+                children={message.content}
+                components={{
+                  p: (props) => <p className="margin-0">{props.children}</p>,
+                }}
+              />
             </Alert>
           );
         })}

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 // components
 import { Alert } from 'components/alert';
 import { Loading } from 'components/loading';
+import { MarkdownContent } from 'components/markdownContent';
 import { Summary } from 'components/summary';
 // contexts
 import { useContentState } from 'contexts/content';
@@ -19,26 +20,6 @@ export default NationalDownloads;
 export function NationalDownloads() {
   const { content } = useContentState();
 
-  return (
-    <div>
-      <h1>National Downloads</h1>
-      <Summary heading="Description">
-        <p>
-          Datasets provided on this page are available as prepackaged national
-          downloads. They are produced and periodically updated by EPA using
-          state-submitted data.
-        </p>
-      </Summary>
-      <NationalDownloadsData content={content} />
-    </div>
-  );
-}
-
-type NationalDownloadsDataProps = {
-  content: FetchState<Content>;
-};
-
-function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
   const status = content.status;
 
   if (status === 'failure')
@@ -53,59 +34,91 @@ function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
 
   if (status === 'success')
     return (
-      <section className="margin-top-6" id="attains">
-        <h2 className="text-primary">ATTAINS Data</h2>
-        Go to the <Link to="/attains">ATTAINS Query</Link> page.
-        <table className="margin-x-auto usa-table usa-table--stacked width-full">
-          <colgroup span={1}></colgroup>
-          <colgroup span={1}></colgroup>
-          <colgroup span={1}></colgroup>
-          <colgroup span={2}></colgroup>
-          <thead>
-            <tr>
-              <th scope="col" rowSpan={2}>Download link</th>
-              <th scope="col" rowSpan={2}>Time last refreshed</th>
-              <th scope="col" rowSpan={2}>Number of rows</th>
-              <th scope="colgroup" colSpan={2} className="text-center">File size</th>
-            </tr>
-            <tr>
-              <th scope="col">Zipped</th>
-              <th scope="col">Unzipped</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(content.data.metadata)
-              .sort((a, b) => a[0].localeCompare(b[0]))
-              .map(([profile, fileInfo]) => (
-                <tr key={profile}>
-                  <th scope="row" data-label="Download link">
-                    <a href={fileInfo.url}>
-                      {content.data.profileConfig[profile].label} Profile
-                      <Exit
-                        aria-hidden="true"
-                        className="height-2 margin-left-05 text-primary top-05 usa-icon width-2"
-                        focusable="false"
-                        role="img"
-                        title="Exit EPA's Website"
-                      />
-                    </a>
-                  </th>
-                  <td data-label="Time last refreshed">
-                    {formatDate(fileInfo.timestamp)}
-                  </td>
-                  <td data-label="Number of rows">
-                    {fileInfo.numRows.toLocaleString()}
-                  </td>
-                  <td data-label="Zipped File size">{formatBytes(fileInfo.zipSize)}</td>
-                  <td data-label="Unzipped File size">{formatBytes(fileInfo.csvSize)}</td>
-                </tr>
-              ))}
-          </tbody>
-        </table>
-      </section>
+      <div>
+        <h1>{content.data.nationalDownloads.heading}</h1>
+        {content.data.nationalDownloads.infoMessages.map((message) => (
+          <Summary heading={message.heading}>
+            <MarkdownContent children={message.content} />
+          </Summary>
+        ))}
+        <NationalDownloadsData content={content} />
+      </div>
     );
 
   return null;
+}
+
+type NationalDownloadsDataProps = {
+  content: FetchState<Content>;
+};
+
+function NationalDownloadsData({ content }: NationalDownloadsDataProps) {
+  if (content.status !== 'success') return null;
+
+  return (
+    <section className="margin-top-6" id="attains">
+      <h2 className="text-primary">ATTAINS Data</h2>
+      Go to the <Link to="/attains">ATTAINS Query</Link> page.
+      <table className="margin-x-auto usa-table usa-table--stacked width-full">
+        <colgroup span={1}></colgroup>
+        <colgroup span={1}></colgroup>
+        <colgroup span={1}></colgroup>
+        <colgroup span={2}></colgroup>
+        <thead>
+          <tr>
+            <th scope="col" rowSpan={2}>
+              Download link
+            </th>
+            <th scope="col" rowSpan={2}>
+              Time last refreshed
+            </th>
+            <th scope="col" rowSpan={2}>
+              Number of rows
+            </th>
+            <th scope="colgroup" colSpan={2} className="text-center">
+              File size
+            </th>
+          </tr>
+          <tr>
+            <th scope="col">Zipped</th>
+            <th scope="col">Unzipped</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(content.data.metadata)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .map(([profile, fileInfo]) => (
+              <tr key={profile}>
+                <th scope="row" data-label="Download link">
+                  <a href={fileInfo.url}>
+                    {content.data.profileConfig[profile].label} Profile
+                    <Exit
+                      aria-hidden="true"
+                      className="height-2 margin-left-05 text-primary top-05 usa-icon width-2"
+                      focusable="false"
+                      role="img"
+                      title="Exit EPA's Website"
+                    />
+                  </a>
+                </th>
+                <td data-label="Time last refreshed">
+                  {formatDate(fileInfo.timestamp)}
+                </td>
+                <td data-label="Number of rows">
+                  {fileInfo.numRows.toLocaleString()}
+                </td>
+                <td data-label="Zipped File size">
+                  {formatBytes(fileInfo.zipSize)}
+                </td>
+                <td data-label="Unzipped File size">
+                  {formatBytes(fileInfo.csvSize)}
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </section>
+  );
 }
 
 /*

--- a/app/server/app/content/config/nationalDownloads.json
+++ b/app/server/app/content/config/nationalDownloads.json
@@ -3,7 +3,7 @@
   "infoMessages": [
     {
       "heading": "Description",
-      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data.",
+      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data.  \n  \nYou may need additional software to view some of the links on this page. See [scheduled maintenance](https://www.epa.gov/home/free-viewers-and-readers-read-and-print-epa-information \"external\")",
       "type": "summary"
     }
   ]

--- a/app/server/app/content/config/nationalDownloads.json
+++ b/app/server/app/content/config/nationalDownloads.json
@@ -1,0 +1,9 @@
+{
+  "heading": "National Downloads",
+  "infoMessages": [
+    {
+      "heading": "Description",
+      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data."
+    }
+  ]
+}

--- a/app/server/app/content/config/nationalDownloads.json
+++ b/app/server/app/content/config/nationalDownloads.json
@@ -3,7 +3,8 @@
   "infoMessages": [
     {
       "heading": "Description",
-      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data."
+      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data.",
+      "type": "summary"
     }
   ]
 }

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -194,6 +194,7 @@ export default function (app, basePath) {
       'content/config/fields.json',
       'content/config/listOptions.json',
       'content/config/profiles.json',
+      'content/config/nationalDownloads.json',
     ];
 
     const filePromises = Promise.all(
@@ -213,6 +214,7 @@ export default function (app, basePath) {
           filterConfig: data[4],
           listOptions: data[5],
           profileConfig: data[6],
+          nationalDownloads: data[7],
         };
       });
 


### PR DESCRIPTION
## Related Issues:
* [EQ-303](https://jira.epa.gov/browse/EQ-303)
* [EQ-304](https://jira.epa.gov/browse/EQ-304)

## Main Changes:
* Updated the national downloads page to be a bit more dynamic, by pulling more stuff from S3. 
* Added a disclaimer about possibly needing other software to open zip files.

## Steps To Test:
1. Navigate to http://localhost:3000/national-downloads
2. Verify everything loads correctly
3. Verify there is a disclaimer in the description box.
4. Update the `server/app/content/config/nationalDownloads.json` file with the content below
5. Reload the page
6. Verify everything loads correctly and that there is a warning below the description box

```
{
  "heading": "National Downloads",
  "infoMessages": [
    {
      "heading": "Description",
      "content": "Datasets provided on this page are available as prepackaged national downloads. They are produced and periodically updated by EPA using state-submitted data.  \n  \nYou may need additional software to view some of the links on this page. See [scheduled maintenance](https://www.epa.gov/home/free-viewers-and-readers-read-and-print-epa-information \"external\")",
      "type": "summary"
    },
    {
      "heading": "",
      "content": "There will be [scheduled maintenance](https://www.epa.gov \"external\") on the **ATTAINS** services on Thursday, July 16th starting at 8am and ending at 11am.",
      "type": "warning"
    }
  ]
}
```
