### PR TITLE
Feature/312 nogo logging

### DIFF
--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -134,7 +134,7 @@ export async function checkLogTables() {
           end_time TIMESTAMP,
           load_error VARCHAR,
           start_time TIMESTAMP,
-          s3_julian VARCHAR(20) NOT NULL,
+          s3_julian VARCHAR(20),
           extract_error VARCHAR
         )`,
     );
@@ -1058,7 +1058,7 @@ export async function isDataReady(pool) {
       etlLogId = await logEtlExtractStart(pool, julian);
     }
 
-    // see if this julian has already been loaded into the db
+    // check etl status to ensure it isn't already running
     const etlRunning = await pool.query(
       'SELECT database FROM logging.etl_status',
     );
@@ -1069,7 +1069,7 @@ export async function isDataReady(pool) {
       return { ready: false, julian, logId: etlLogId };
     }
 
-    // check etl status to ensure it isn't already running
+    // see if this julian has already been loaded into the db
     const result = await pool.query(
       `
         SELECT active FROM logging.etl_schemas WHERE s3_julian = $1

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -431,8 +431,8 @@ async function logEtlExtractError(pool, etlLogId, extractError) {
 async function logEtlExtractStart(pool, s3Julian) {
   try {
     const result = await pool.query(
-      'INSERT INTO logging.etl_log (s3_julian)' +
-        ` VALUES (${s3Julian}) RETURNING id`,
+      'INSERT INTO logging.etl_log (s3_julian) VALUES ($1) RETURNING id',
+      [s3Julian],
     );
     log.info('ETL extract start logged');
     return result.rows[0].id;


### PR DESCRIPTION
## Related Issues:
* [EQ-312](https://jira.epa.gov/browse/EQ-312)

## Main Changes:
* Updated the `etl_log` table to include a column for problems as reported by the extract process.
* Added an `s3_julian` to the `etl_log` table, which is checked to prevent duplicate log entries.
  * It's necessary to include this timestamp in the table, rather than calculating it from `etl_schemas`, because if there are problems they are inserted before schema creation. If we want to avoid duplication and drop the column from `etl_schemas`, we can switch to getting the `s3_julian` of schemas present via joining on `schema_id`.
* Since logging the start time occurs after problems are logged, the `NOT NULL` constraint was removed from the `start_time` column in `etl_log`.

## Steps To Test:
1. Point the ETL app at a local database.
2. Add the `s3_julian` and `extract_error` columns to the `etl_log` table, and remove the `NOT NULL` constraint from the `start_time` column. This can be accomplished by dropping and regenerating the database or executing the following commands:
```
ALTER TABLE logging.etl_log ADD COLUMN s3_julian VARCHAR(20);
ALTER TABLE logging.etl_log ADD COLUMN extract_error VARCHAR;
ALTER TABLE logging.etl_log ALTER COLUMN start_time DROP NOT NULL;
```
4. Ensure the `national-downloads` folder is populated with a valid `latest.json` file and a corresponding directory with at least a `ready.json` file inside. Add some problems to the `ready.json` file. Increment the s3_julian in `latest.json`, and rename the corresponding directory to match.
6. Run the ETL.
7. Inspect the `etl_log` table. The problems should be present in the `extract_error` column.
8. Run the ETL again.
9. Ensure that no new rows are added to the table. 