### PR TITLE
feature/327_cast-dates-as-strings

### DIFF
--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -330,10 +330,12 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
     // build the select query
     const selectColumns =
       columnsToReturn.length > 0 ? columnsToReturn : profile.columns;
-    const selectText = selectColumns.map((col) =>
-      col.name === col.alias ? col.name : `${col.name} AS ${col.alias}`,
-    );
-    query.select(selectText).orderBy('objectid', 'asc');
+    const selectText = selectColumns.map((col) => {
+      const name =
+        col.type === 'timestamptz' ? `${col.name}::VARCHAR(100)` : col.name;
+      return col.name === col.alias ? name : `${name} AS ${col.alias}`;
+    });
+    query.select(knex.raw(selectText)).orderBy('objectid', 'asc');
   }
 
   // build where clause of the query


### PR DESCRIPTION
## Related Issues:
* [EQ-327](https://jira.epa.gov/browse/EQ-327)

## Main Changes:
* Fixed issue of csv export including time for dates that don't have it.

## Steps To Test:
1. Navigate to http://localhost:3000/attains/assessments?assessmentUnitId=TN05130206002_1000&assessmentUnitStatus=A&state=TN#download
2. Download as a xlsx
3. Open the file and verify the `assessmentDate` column is formatted as `2017-03-05`
4. Download as a csv
5. Open the file in a plain text editor, such as notepad++, and verify the `assessmentDate` column is formatted as `2017-03-05`
    * For some reason opening the csv file in excel will format the `assessmentDate` column as `3/15/2017`. I think as long as the plain text csv matches what we have in xlsx, we are fine.
    * If you do the same query above on the dev or stage site and download as a csv, the `assessmentDate` column is formatted as `2017-03-15T04:00:00.000Z`

