### PR TITLE
Feature/334 improve etl database status

### DIFF
--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -758,25 +758,23 @@ async function checkDatabaseHealth(req, res) {
     query.where('active', true);
     const activeSchemaResults = await query;
 
-    if (!etlRunning) {
-      // verify database updated in the last week, with 6 hour buffer
-      const timeSinceLastUpdate =
-        (Date.now() - activeSchemaResults.end_time) / (1000 * 60 * 60);
-      if (timeSinceLastUpdate >= 175) {
-        setStatus('FAILED-TIME');
-      }
+    // verify database updated in the last week, with 6 hour buffer
+    const timeSinceLastUpdate =
+      (Date.now() - activeSchemaResults.end_time) / (1000 * 60 * 60);
+    if (timeSinceLastUpdate >= 175) {
+      setStatus('FAILED-TIME');
+    }
 
-      // verify a query can be ran against each table in the active db
-      for (const profile of Object.values(privateConfig.tableConfig)) {
-        query = knex
-          .withSchema(req.activeSchema)
-          .from(profile.tableName)
-          .select(profile.idColumn)
-          .limit(1)
-          .first();
-        const dataResults = await query;
-        if (!dataResults[profile.idColumn]) setStatus('FAILED-QUERY');
-      }
+    // verify a query can be ran against each table in the active db
+    for (const profile of Object.values(privateConfig.tableConfig)) {
+      query = knex
+        .withSchema(req.activeSchema)
+        .from(profile.tableName)
+        .select(profile.idColumn)
+        .limit(1)
+        .first();
+      const dataResults = await query;
+      if (!dataResults[profile.idColumn]) setStatus('FAILED-QUERY');
     }
 
     const output = {

--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -758,23 +758,25 @@ async function checkDatabaseHealth(req, res) {
     query.where('active', true);
     const activeSchemaResults = await query;
 
-    // verify database updated in the last week, with 6 hour buffer
-    const timeSinceLastUpdate =
-      (Date.now() - activeSchemaResults.end_time) / (1000 * 60 * 60);
-    if (timeSinceLastUpdate >= 175 && !etlRunning) {
-      setStatus('FAILED-TIME');
-    }
+    if (!etlRunning) {
+      // verify database updated in the last week, with 6 hour buffer
+      const timeSinceLastUpdate =
+        (Date.now() - activeSchemaResults.end_time) / (1000 * 60 * 60);
+      if (timeSinceLastUpdate >= 175) {
+        setStatus('FAILED-TIME');
+      }
 
-    // verify a query can be ran against each table in the active db
-    for (const profile of Object.values(privateConfig.tableConfig)) {
-      query = knex
-        .withSchema(req.activeSchema)
-        .from(profile.tableName)
-        .select(profile.idColumn)
-        .limit(1)
-        .first();
-      const dataResults = await query;
-      if (!dataResults[profile.idColumn]) setStatus('FAILED-QUERY');
+      // verify a query can be ran against each table in the active db
+      for (const profile of Object.values(privateConfig.tableConfig)) {
+        query = knex
+          .withSchema(req.activeSchema)
+          .from(profile.tableName)
+          .select(profile.idColumn)
+          .limit(1)
+          .first();
+        const dataResults = await query;
+        if (!dataResults[profile.idColumn]) setStatus('FAILED-QUERY');
+      }
     }
 
     const output = {
@@ -792,7 +794,7 @@ async function checkDatabaseHealth(req, res) {
 
     // if ids of schemaResults and activeSchemaResults don't match then add failed
     if (schemaResults.id !== activeSchemaResults.id) {
-      output.failed = {
+      output[etlRunning ? 'inProgress' : 'failed'] = {
         completed: schemaResults.end_time?.toLocaleString(),
         duration: schemaResults.duration,
         s3Uuid: schemaResults.s3_julian,

--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -732,6 +732,8 @@ async function checkDatabaseHealth(req, res) {
     const statusResults = await query;
     if (statusResults.database === 'failed') setStatus('FAILED-DB');
 
+    const etlRunning = statusResults.database === 'running';
+
     // verify the latest entry in the schema table is active
     query = knex
       .withSchema('logging')
@@ -748,7 +750,7 @@ async function checkDatabaseHealth(req, res) {
       .orderBy('creation_date', 'desc')
       .first();
     const schemaResults = await query;
-    if (!schemaResults.active && statusResults.database !== 'running') {
+    if (!schemaResults.active && !etlRunning) {
       setStatus('FAILED-SCHEMA');
     }
 
@@ -756,10 +758,12 @@ async function checkDatabaseHealth(req, res) {
     query.where('active', true);
     const activeSchemaResults = await query;
 
-    // verify database updated in the last week, with 1 hour buffer
+    // verify database updated in the last week, with 6 hour buffer
     const timeSinceLastUpdate =
-      (Date.now() - activeSchemaResults.creation_date) / (1000 * 60 * 60);
-    if (timeSinceLastUpdate >= 169) setStatus('FAILED-TIME');
+      (Date.now() - activeSchemaResults.end_time) / (1000 * 60 * 60);
+    if (timeSinceLastUpdate >= 175 && !etlRunning) {
+      setStatus('FAILED-TIME');
+    }
 
     // verify a query can be ran against each table in the active db
     for (const profile of Object.values(privateConfig.tableConfig)) {
@@ -775,6 +779,7 @@ async function checkDatabaseHealth(req, res) {
 
     const output = {
       status,
+      etlRunning,
       lastSuccess: {
         completed: activeSchemaResults.end_time?.toLocaleString(),
         duration: activeSchemaResults.duration,


### PR DESCRIPTION
## Related Issues:
* [EQ-334](https://jira.epa.gov/browse/EQ-334)

## Main Changes:
* Updated the `FAILED-TIME` status to be based on the etl's `end_time` column instead of the `creation_date` column.
* Updated the `FAILED-TIME` status to only be triggered if more than 1 week and 6 hours (or 175 hours) has passed prior to the etl starting to run. 
* Added a `etlRunning` field to the output. 
* Updated the second schema field to be `failed` if `etlRunning = false` or `inProgress` if `etlRunning = true`. 

## Steps To Test:
1. Make sure the app is connected to your local DB.
2. Navigate to http://localhost:9090/api/attains/health/etlDatabase
3. Manually update your local database to test above changes and refresh browser. Related tables are `etl_status`, `etl_log` and `etl_schemas`.
