### PR TITLE
Bugfix/352 browser console errors

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -333,6 +333,7 @@
               class="usa-accordion__button usa-banner__button"
               aria-expanded="false"
               aria-controls="gov-banner"
+              onclick="toggleBanner()"
             >
               <span class="usa-banner__button-text">Here’s how you know</span>
             </button>
@@ -836,20 +837,20 @@
     </style>
 
     <script>
-      const bannerHeader = document.querySelector('.usa-banner__header');
-      const bannerContent = document.querySelector('#gov-banner');
-      const bannerButton = bannerHeader.querySelector('.usa-banner__button');
-      bannerButton.onclick = function () {
-        if (bannerButton.ariaExpanded === true) {
-          bannerButton.ariaExpanded = false;
+      function toggleBanner() {
+        const bannerHeader = document.querySelector('.usa-banner__header');
+        const bannerContent = document.querySelector('#gov-banner');
+        const bannerButton = bannerHeader.querySelector('.usa-banner__button');
+        if (bannerButton.getAttribute('aria-expanded') === 'true') {
+          bannerButton.setAttribute('aria-expanded', 'false');
           bannerHeader.classList.remove('usa-banner__header--expanded');
           bannerContent.hidden = true;
         } else {
-          bannerButton.ariaExpanded = true;
+          bannerButton.setAttribute('aria-expanded', 'true');
           bannerHeader.classList.add('usa-banner__header--expanded');
           bannerContent.hidden = false;
         }
-      };
+      }
     </script>
 
     <script>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -33,7 +33,11 @@
     <meta name="twitter:image:width" content="1200" />
     <meta name="msapplication-TileColor" content="#005ea2" />
     <meta name="theme-color" content="#005ea2" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      rel="manifest"
+      href="%PUBLIC_URL%/manifest.json"
+      crossorigin="anonymous"
+    />
     <link rel="canonical" href="%PUBLIC_URL%/" />
     <link
       rel="apple-touch-icon-precomposed"

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -339,7 +339,11 @@
           </div>
         </header>
 
-        <div id="gov-banner" class="usa-banner__content usa-accordion__content">
+        <div
+          id="gov-banner"
+          class="usa-banner__content usa-accordion__content"
+          hidden="true"
+        >
           <div class="grid-row grid-gap-lg">
             <div class="usa-banner__guidance tablet:grid-col-6">
               <img
@@ -830,6 +834,23 @@
         }
       }
     </style>
+
+    <script>
+      const bannerHeader = document.querySelector('.usa-banner__header');
+      const bannerContent = document.querySelector('#gov-banner');
+      const bannerButton = bannerHeader.querySelector('.usa-banner__button');
+      bannerButton.onclick = function () {
+        if (bannerButton.ariaExpanded === true) {
+          bannerButton.ariaExpanded = false;
+          bannerHeader.classList.remove('usa-banner__header--expanded');
+          bannerContent.hidden = true;
+        } else {
+          bannerButton.ariaExpanded = true;
+          bannerHeader.classList.add('usa-banner__header--expanded');
+          bannerContent.hidden = false;
+        }
+      };
+    </script>
 
     <script>
       (function () {


### PR DESCRIPTION
## Related Issues:
* [EQ-352](https://jira.epa.gov/browse/EQ-352)

## Main Changes:
* Added a script to restore the USA banner behavior after dropping the EPA template's scripts.
* Added a `crossorigin` attribute to the manifest's `<link>` tag.

## Steps To Test:
1. Go to http://localhost:3000/attains.
2. Confirm the "An official website of the United States government" banner is collapsed.
3. Click the "Here's how you know" button/link, confirm the banner expands and collapses.
4. Test the above in multiple browsers.
5. After merging, test dev to make sure there are no errors concerning the `manifest.json` file in Chrome.