### PR TITLE
bugfix/366_ api signup page issue

### DIFF
--- a/app/client/src/routes/apiKeySignup.tsx
+++ b/app/client/src/routes/apiKeySignup.tsx
@@ -46,7 +46,9 @@ export function ApiKeySignup() {
         use <b>Expert Query</b>'s web services, then explore the web service{' '}
         <Link to={`${serverUrl}/api-documentation`}>documentation</Link>.
       </p>
-      <div id="apidatagov_signup">{loading && <Loading />}</div>
+
+      {loading && <Loading />}
+      <div id="apidatagov_signup"></div>
     </div>
   );
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-366](https://jira.epa.gov/browse/EQ-366)

## Main Changes:
* Fixed issue where the api signup page was crashing. I tracked the issue down to a conditionally rendered loading spinner being inside the div for the api.data.gov form. I'm not entirely sure why we didn't see this error before. I suspect the `recaptcha` library (imported by api.data.gov form) was updated and caused the issue. 

## Steps To Test:
1. Navigate to http://localhost:3000/api-key-signup
2. Verify the signup page loads

