### PR TITLE
Feature/400 allow nulls in config

### DIFF
--- a/app/client/src/components/checkboxes.tsx
+++ b/app/client/src/components/checkboxes.tsx
@@ -55,7 +55,7 @@ export function Checkboxes({
               }
             }}
             tile={tile}
-            value={option.value.toString()}
+            value={option.value?.toString()}
           />
         );
       })}

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1293,8 +1293,17 @@ async function checkColumnValue(
   fieldName: string,
   profile: string,
 ) {
-  const url = `${apiUrl}/${profile}/values/${fieldName}?${fieldName}=${value}&limit=1`;
-  const res = await getData<string[]>({ url, apiKey });
+  const url = `${apiUrl}/${profile}/values/${fieldName}`;
+  const data = {
+    [fieldName]: value,
+    limit: 1,
+  };
+  const res = await postData({
+    url,
+    apiKey,
+    data,
+    responseType: 'json',
+  });
   if (res.length) return true;
   return false;
 }

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -29,7 +29,7 @@ import { useContentState } from 'contexts/content';
 // config
 import { serverUrl } from 'config';
 // utils
-import { getData, isAbort, postData, useAbort } from 'utils';
+import { isAbort, postData, useAbort } from 'utils';
 // types
 import type { Content } from 'contexts/content';
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react';

--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -363,7 +363,7 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
     const exactArg = queryParams.filters[col.alias];
     if (lowArg || highArg) {
       appendRangeToWhere(query, col, lowArg, highArg);
-    } else if (exactArg) {
+    } else if (exactArg !== undefined) {
       appendToWhere(query, col.name, queryParams.filters[col.alias]);
     }
   });


### PR DESCRIPTION
## Related Issues:
* [EQ-400](https://jira.epa.gov/browse/EQ-400)
* [EQ-407](https://jira.epa.gov/browse/EQ-407)

## Main Changes:
* Updated the app to allow setting configuration to query for null values. 
  * I initially considered having the configuration take actuall nulls. I ended up using a string with a null for the text, mainly because it plays nicely with our logic for auto populating selections based on the URL. I checked our database and we don't have any values that are a string with "null" for the text. Also, null in the address bar is interpreted as a string, so we wouldn't be able to tell if the intension was a null or a string with null for the text. The web service allows querying for actual nulls.
* Fixed an issue where certain fields were not being autopopulated from the URL. The fields that were an issue were fields that queried the `values` service. For filtering dropdowns, we were calling values with a post request, which works. For the auto populating logic we used a get request, which is a non-existent endpoint.

## Steps To Test:
1. In `app/server/app/content/config/listOptions.json`,  add `{ "label": "Not Specified", "value": "null" }` after line 9.
2. In `app/server/app/content-etl/domainValues/assessmentTypes.json`, add `{"label":"Not Specified","value": "null"}` to the list of assessment types.
3. Navigate to http://localhost:3000/attains/assessments?assessmentTypes=BIOLOGICAL&assessmentTypes=null&assessmentUnitStatus=A&cwa303dPriorityRanking=High&cwa303dPriorityRanking=Low&cwa303dPriorityRanking=null
4. Verify that "Not Specified" is selected in the Assessment Types drop down.
5. Verify that "Not Specified" is checked under CWA 303D Priority Ranking.
6. Test the query and verify it returns the correct results
    * I would recommend adding a `console.log('query: ', query.toString())` to line `516` in the `app/server/app/routes/attains.js` file, so you can verify the query looks correct.
7. Select an organization
8. Refresh the page
9. Verify the org you selected is still selected

## TODO:
- [ ] Get guidance from EPA on what columns that would want to allow querying for nulls on.

