### PR TITLE
Bugfix/387 swagger overflow

### DIFF
--- a/app/client/src/components/inPageNav.tsx
+++ b/app/client/src/components/inPageNav.tsx
@@ -168,7 +168,7 @@ function InPageNavLayoutInner({ children }: { children: ReactNode }) {
           </nav>
         </aside>
       )}
-      <div className="flex-fill">{children}</div>
+      <div className="flex-fill width-full">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-387](https://jira.epa.gov/browse/EQ-387)

## Main Changes:
* Fixed issue with large curl requests causing overflow in swagger ui.

## Steps To Test:
1. Navigate to http://localhost:3000/api-documentation#/ATTAINS%20-%20Actions/get_attains_actions
2. Click `Try it out`
3. Click `Execute`
4. Verify the main content width stays the same
5. Verify the `Curl` box is scrollable
6. Verify other pages still look the same

