### PR TITLE
Feature/425 update 404 return

### DIFF
--- a/app/server/app/index.js
+++ b/app/server/app/index.js
@@ -214,7 +214,7 @@ app.listen(port, function () {
 /* Note, the React app should be handling 404 at this point 
    but we're leaving the below 404 check in for now */
 app.use(function (req, res, next) {
-  res.status(404).sendFile(path.join(__dirname, 'public', '400.html'));
+  res.status(404).sendFile(path.join(__dirname, 'public', '404.html'));
 });
 
 app.use(function (err, req, res, next) {

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -34,7 +34,7 @@ function checkClientRouteExists(req, res, next) {
   clientRoutes.push('/');
 
   if (!clientRoutes.includes(req.path)) {
-    return res.status(404).sendFile(path.join(__dirname, 'public', '400.html'));
+    return res.status(404).sendFile(path.join(__dirname, 'public', '404.html'));
   }
 
   next();

--- a/app/server/app/public/404.html
+++ b/app/server/app/public/404.html
@@ -27,7 +27,7 @@
     <meta property="og:title" content="Expert Query | Page Not Found | US EPA" />
     <meta
       property="og:image"
-      content="./epa-template-files/images/epa-standard-og.jpg"
+      content="/epa-template-files/images/epa-standard-og.jpg"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -51,7 +51,7 @@
     <meta name="twitter:image:width" content="1200" />
     <meta
       name="twitter:image"
-      content="./epa-template-files/images/epa-standard-twitter.jpg"
+      content="/epa-template-files/images/epa-standard-twitter.jpg"
     />
     <meta name="description" content="U.S. EPA Expert Query" />
     <meta property="DC.description" content="U.S. EPA Expert Query" />
@@ -60,95 +60,95 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="./epa-template-files/images/favicon.ico"
+      href="/epa-template-files/images/favicon.ico"
     />
     <meta name="msapplication-TileColor" content="#FFFFFF" />
     <meta
       name="msapplication-TileImage"
-      content="./epa-template-files/images/favicon-144.png"
+      content="/epa-template-files/images/favicon-144.png"
     />
     <meta name="application-name" content="US EPA" />
     <meta
       name="msapplication-config"
-      content="./epa-template-files/ieconfig.xml"
+      content="/epa-template-files/ieconfig.xml"
     />
     <link
       rel="manifest"
-      href="./manifest.json"
+      href="/manifest.json"
       crossorigin="use-credentials"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"
-      href="./epa-template-files/images/favicon-196.png"
+      href="/epa-template-files/images/favicon-196.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="152x152"
-      href="./epa-template-files/images/favicon-152.png"
+      href="/epa-template-files/images/favicon-152.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="144x144"
-      href="./epa-template-files/images/favicon-144.png"
+      href="/epa-template-files/images/favicon-144.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="120x120"
-      href="./epa-template-files/images/favicon-120.png"
+      href="/epa-template-files/images/favicon-120.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="114x114"
-      href="./epa-template-files/images/favicon-114.png"
+      href="/epa-template-files/images/favicon-114.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="72x72"
-      href="./epa-template-files/images/favicon-72.png"
+      href="/epa-template-files/images/favicon-72.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
-      href="./epa-template-files/images/favicon-180.png"
+      href="/epa-template-files/images/favicon-180.png"
     />
     <link
       rel="icon"
-      href="./epa-template-files/images/favicon-32.png"
+      href="/epa-template-files/images/favicon-32.png"
       sizes="32x32"
     />
     <link
       rel="mask-icon"
-      href="./epa-template-files/images/safari-pinned-tab.svg"
+      href="/epa-template-files/images/safari-pinned-tab.svg"
       color="#ffffff"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-italic-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-italic-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/merriweather/Latin-Merriweather-Bold.woff2"
+      href="/epa-template-files/fonts/merriweather/Latin-Merriweather-Bold.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="stylesheet"
       media="all"
-      href="./epa-template-files/css/epa.css"
+      href="/epa-template-files/css/epa.css"
     />
     <!-- Style fixes for the EPA template -->
     <style>
@@ -228,7 +228,7 @@
               <img
                 class="usa-banner__header-flag"
                 aria-hidden="true"
-                src="./epa-template-files/images/us_flag_small.png"
+                src="/epa-template-files/images/us_flag_small.png"
                 alt="U.S. flag"
                 height="11px"
                 width="16px"
@@ -259,7 +259,7 @@
             <div class="usa-banner__guidance tablet:grid-col-6">
               <img
                 class="usa-banner__icon usa-media-block__img"
-                src="./epa-template-files/images/icon-dot-gov.svg"
+                src="/epa-template-files/images/icon-dot-gov.svg"
                 alt="Dot gov"
               />
               <div class="usa-media-block__body">
@@ -276,7 +276,7 @@
             <div class="usa-banner__guidance tablet:grid-col-6">
               <img
                 class="usa-banner__icon usa-media-block__img"
-                src="./epa-template-files/images/icon-https.svg"
+                src="/epa-template-files/images/icon-https.svg"
                 alt="HTTPS"
               />
               <div class="usa-media-block__body">
@@ -329,7 +329,7 @@
                 aria-hidden="true"
               >
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#magnifying-glass"
+                  href="/epa-template-files/images/sprite.artifact.svg#magnifying-glass"
                 ></use>
               </svg>
               <svg
@@ -337,7 +337,7 @@
                 aria-hidden="true"
               >
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#xmark"
+                  href="/epa-template-files/images/sprite.artifact.svg#xmark"
                 ></use>
               </svg>
             </button>
@@ -532,7 +532,7 @@
                 <button class="button" type="submit" aria-label="Search">
                   <svg class="icon usa-search__submit-icon" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#magnifying-glass"
+                      href="/epa-template-files/images/sprite.artifact.svg#magnifying-glass"
                     ></use>
                   </svg>
                   <span class="usa-search__submit-text">Search</span>
@@ -558,7 +558,7 @@
               <svg class="icon icon--nav-close" aria-hidden="true" role="img">
                 <title>Primary navigation</title>
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#xmark"
+                  href="/epa-template-files/images/sprite.artifact.svg#xmark"
                 ></use>
               </svg>
             </button>
@@ -622,7 +622,7 @@
       </h1>
       <div class="main-column">
         <p style="padding-bottom: 0">
-          Return to the <a href="./">homepage</a>.
+          Return to the <a href="/">homepage</a>.
         </p>
       </div>
     </article>
@@ -650,7 +650,7 @@
       <div class="l-constrain">
         <img
           class="footer__epa-seal"
-          src="./epa-template-files/images/epa-seal.svg"
+          src="/epa-template-files/images/epa-seal.svg"
           alt="United States Environmental Protection Agency"
           height="100"
           width="100"
@@ -761,7 +761,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -779,7 +779,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -791,7 +791,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -846,7 +846,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#facebook-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#facebook-square"
                     ></use>
                   </svg>
                 </a>
@@ -859,7 +859,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#twitter-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#twitter-square"
                     ></use>
                   </svg>
                 </a>
@@ -872,7 +872,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#youtube-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#youtube-square"
                     ></use>
                   </svg>
                 </a>
@@ -885,7 +885,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#flickr-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#flickr-square"
                     ></use>
                   </svg>
                 </a>
@@ -898,7 +898,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#instagram-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#instagram-square"
                     ></use>
                   </svg>
                 </a>
@@ -912,19 +912,19 @@
     <a href="#top" class="back-to-top" title="Back to top" aria-hidden="true">
       <svg class="back-to-top__icon" aria-hidden="true">
         <use
-          href="./epa-template-files/images/sprite.artifact.svg#angle"
+          href="/epa-template-files/images/sprite.artifact.svg#angle"
         ></use>
       </svg>
     </a>
 
     <script
-      src="./epa-template-files/js/once.min.js"
+      src="/epa-template-files/js/once.min.js"
     ></script>
     <script
-      src="./epa-template-files/js/common.min.js"
+      src="/epa-template-files/js/common.min.js"
     ></script>
     <script
-      src="./epa-template-files/js/scripts.min.js"
+      src="/epa-template-files/js/scripts.min.js"
     ></script>
     <!-- EPA template script mobile drawer fix -->
     <script>

--- a/app/server/app/public/404.html
+++ b/app/server/app/public/404.html
@@ -9,8 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Expert Query | Page Not Found | US EPA</title>
 
-    <link rel="canonical" href="https://owapps.epa.gov/expertquery/400.html" />
-    <link rel="shortlink" href="https://owapps.epa.gov/expertquery/400.html" />
+    <link rel="canonical" href="https://owapps.epa.gov/expertquery/404.html" />
+    <link rel="shortlink" href="https://owapps.epa.gov/expertquery/404.html" />
     <meta name="DC.title" content="Expert Query | Page Not Found" />
     <meta property="DC.Subject.epachannel" content="Learn the Issues" />
     <meta property="DC.type" content="Overviews and Factsheets" />
@@ -23,7 +23,7 @@
     <meta property="ContentType" content="Basic page" />
     <meta property="og:site_name" content="US EPA" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://owapps.epa.gov/expertquery/400.html" />
+    <meta property="og:url" content="https://owapps.epa.gov/expertquery/404.html" />
     <meta property="og:title" content="Expert Query | Page Not Found | US EPA" />
     <meta
       property="og:image"

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -27,7 +27,7 @@
     <meta property="og:title" content="Expert Query | Internal Server Error | US EPA" />
     <meta
       property="og:image"
-      content="./epa-template-files/images/epa-standard-og.jpg"
+      content="/epa-template-files/images/epa-standard-og.jpg"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -51,7 +51,7 @@
     <meta name="twitter:image:width" content="1200" />
     <meta
       name="twitter:image"
-      content="./epa-template-files/images/epa-standard-twitter.jpg"
+      content="/epa-template-files/images/epa-standard-twitter.jpg"
     />
     <meta name="description" content="U.S. EPA Expert Query" />
     <meta property="DC.description" content="U.S. EPA Expert Query" />
@@ -60,95 +60,95 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="./epa-template-files/images/favicon.ico"
+      href="/epa-template-files/images/favicon.ico"
     />
     <meta name="msapplication-TileColor" content="#FFFFFF" />
     <meta
       name="msapplication-TileImage"
-      content="./epa-template-files/images/favicon-144.png"
+      content="/epa-template-files/images/favicon-144.png"
     />
     <meta name="application-name" content="US EPA" />
     <meta
       name="msapplication-config"
-      content="./epa-template-files/ieconfig.xml"
+      content="/epa-template-files/ieconfig.xml"
     />
     <link
       rel="manifest"
-      href="./manifest.json"
+      href="/manifest.json"
       crossorigin="use-credentials"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="196x196"
-      href="./epa-template-files/images/favicon-196.png"
+      href="/epa-template-files/images/favicon-196.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="152x152"
-      href="./epa-template-files/images/favicon-152.png"
+      href="/epa-template-files/images/favicon-152.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="144x144"
-      href="./epa-template-files/images/favicon-144.png"
+      href="/epa-template-files/images/favicon-144.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="120x120"
-      href="./epa-template-files/images/favicon-120.png"
+      href="/epa-template-files/images/favicon-120.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="114x114"
-      href="./epa-template-files/images/favicon-114.png"
+      href="/epa-template-files/images/favicon-114.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
       sizes="72x72"
-      href="./epa-template-files/images/favicon-72.png"
+      href="/epa-template-files/images/favicon-72.png"
     />
     <link
       rel="apple-touch-icon-precomposed"
-      href="./epa-template-files/images/favicon-180.png"
+      href="/epa-template-files/images/favicon-180.png"
     />
     <link
       rel="icon"
-      href="./epa-template-files/images/favicon-32.png"
+      href="/epa-template-files/images/favicon-32.png"
       sizes="32x32"
     />
     <link
       rel="mask-icon"
-      href="./epa-template-files/images/safari-pinned-tab.svg"
+      href="/epa-template-files/images/safari-pinned-tab.svg"
       color="#ffffff"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-regular-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-bold-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/source-sans-pro/sourcesanspro-italic-webfont.woff2"
+      href="/epa-template-files/fonts/source-sans-pro/sourcesanspro-italic-webfont.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="preload"
-      href="./epa-template-files/fonts/merriweather/Latin-Merriweather-Bold.woff2"
+      href="/epa-template-files/fonts/merriweather/Latin-Merriweather-Bold.woff2"
       as="font"
       crossorigin="anonymous"
     />
     <link
       rel="stylesheet"
       media="all"
-      href="./epa-template-files/css/epa.css"
+      href="/epa-template-files/css/epa.css"
     />
     <!-- Style fixes for the EPA template -->
     <style>
@@ -228,7 +228,7 @@
               <img
                 class="usa-banner__header-flag"
                 aria-hidden="true"
-                src="./epa-template-files/images/us_flag_small.png"
+                src="/epa-template-files/images/us_flag_small.png"
                 alt="U.S. flag"
                 height="11px"
                 width="16px"
@@ -259,7 +259,7 @@
             <div class="usa-banner__guidance tablet:grid-col-6">
               <img
                 class="usa-banner__icon usa-media-block__img"
-                src="./epa-template-files/images/icon-dot-gov.svg"
+                src="/epa-template-files/images/icon-dot-gov.svg"
                 alt="Dot gov"
               />
               <div class="usa-media-block__body">
@@ -276,7 +276,7 @@
             <div class="usa-banner__guidance tablet:grid-col-6">
               <img
                 class="usa-banner__icon usa-media-block__img"
-                src="./epa-template-files/images/icon-https.svg"
+                src="/epa-template-files/images/icon-https.svg"
                 alt="HTTPS"
               />
               <div class="usa-media-block__body">
@@ -329,7 +329,7 @@
                 aria-hidden="true"
               >
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#magnifying-glass"
+                  href="/epa-template-files/images/sprite.artifact.svg#magnifying-glass"
                 ></use>
               </svg>
               <svg
@@ -337,7 +337,7 @@
                 aria-hidden="true"
               >
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#xmark"
+                  href="/epa-template-files/images/sprite.artifact.svg#xmark"
                 ></use>
               </svg>
             </button>
@@ -532,7 +532,7 @@
                 <button class="button" type="submit" aria-label="Search">
                   <svg class="icon usa-search__submit-icon" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#magnifying-glass"
+                      href="/epa-template-files/images/sprite.artifact.svg#magnifying-glass"
                     ></use>
                   </svg>
                   <span class="usa-search__submit-text">Search</span>
@@ -558,7 +558,7 @@
               <svg class="icon icon--nav-close" aria-hidden="true" role="img">
                 <title>Primary navigation</title>
                 <use
-                  href="./epa-template-files/images/sprite.artifact.svg#xmark"
+                  href="/epa-template-files/images/sprite.artifact.svg#xmark"
                 ></use>
               </svg>
             </button>
@@ -643,7 +643,7 @@
       <div class="l-constrain">
         <img
           class="footer__epa-seal"
-          src="./epa-template-files/images/epa-seal.svg"
+          src="/epa-template-files/images/epa-seal.svg"
           alt="United States Environmental Protection Agency"
           height="100"
           width="100"
@@ -754,7 +754,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -772,7 +772,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -784,7 +784,7 @@
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
-                      href="./epa-template-files/images/sprite.svg#launch"
+                      href="/epa-template-files/images/sprite.svg#launch"
                     ></use>
                   </svg>
                 </a>
@@ -839,7 +839,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#facebook-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#facebook-square"
                     ></use>
                   </svg>
                 </a>
@@ -852,7 +852,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#twitter-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#twitter-square"
                     ></use>
                   </svg>
                 </a>
@@ -865,7 +865,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#youtube-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#youtube-square"
                     ></use>
                   </svg>
                 </a>
@@ -878,7 +878,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#flickr-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#flickr-square"
                     ></use>
                   </svg>
                 </a>
@@ -891,7 +891,7 @@
                 >
                   <svg class="icon icon--social" aria-hidden="true">
                     <use
-                      href="./epa-template-files/images/sprite.artifact.svg#instagram-square"
+                      href="/epa-template-files/images/sprite.artifact.svg#instagram-square"
                     ></use>
                   </svg>
                 </a>
@@ -905,19 +905,19 @@
     <a href="#top" class="back-to-top" title="Back to top" aria-hidden="true">
       <svg class="back-to-top__icon" aria-hidden="true">
         <use
-          href="./epa-template-files/images/sprite.artifact.svg#angle"
+          href="/epa-template-files/images/sprite.artifact.svg#angle"
         ></use>
       </svg>
     </a>
 
     <script
-      src="./epa-template-files/js/once.min.js"
+      src="/epa-template-files/js/once.min.js"
     ></script>
     <script
-      src="./epa-template-files/js/common.min.js"
+      src="/epa-template-files/js/common.min.js"
     ></script>
     <script
-      src="./epa-template-files/js/scripts.min.js"
+      src="/epa-template-files/js/scripts.min.js"
     ></script>
     <!-- EPA template script mobile drawer fix -->
     <script>

--- a/app/server/app/routes/404.js
+++ b/app/server/app/routes/404.js
@@ -7,7 +7,7 @@ export default function (app, basePath) {
   const router = express.Router();
 
   router.get('/', function (req, res, next) {
-    res.status(404).sendFile(path.join(__dirname, '../public', '400.html'));
+    res.status(404).sendFile(path.join(__dirname, '../public', '404.html'));
   });
 
   app.use(`${basePath}404.html`, router);

--- a/app/server/app/routes/api.js
+++ b/app/server/app/routes/api.js
@@ -262,4 +262,8 @@ export default function (app, basePath) {
   });
 
   app.use(`${basePath}api`, router);
+
+  app.get('/api/*', (req, res) => {
+    res.status(404).json({ message: 'The api route does not exist.' });
+  });
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-425](https://jira.epa.gov/browse/EQ-425)

## Main Changes:
* Updated the server to return a json based error message for non-existent routes under `api/*`. Other non-existent routes still return the 404 html file.
  * Brad and I were doing some testing earlier in HMW and decided that HMW and EQ should both return a json based error under the `api/*` path.
* Renamed `400.html` to `404.html`. 404 just makes more sense, since we are trying to catch non-existent routes. 

## Steps To Test:
1. Open dev tools console
2. Navigate to http://localhost:3000/attains/actions
3. Verify the app loads
4. Click download
5. Verify you get a count back
6. Navigate to http://localhost:9090/sdvsv
7. Verify you get a `Sorry, but this web page does not exist.` message and the status code is 404
8. Navigate to http://localhost:9090/bogusRoute/
9. Verify you get an html file with the error
10. Navigate to http://localhost:9090/api/bogusRoute/
11. Verify you get a json error message
12. Navigate to http://localhost:9090/api/attains/bogusRoute/
13. Verify you get a json error message

