### PR TITLE
Feature/428 any reporting cycle query

### DIFF
--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -1427,7 +1427,7 @@ function filterDynamicOptions({
     return {
       options:
         !lastLoadedOption && defaultOption // only include default option in first page
-          ? [defaultOption, ...options, ...additionalOptions]
+          ? [defaultOption, ...additionalOptions, ...options]
           : options,
       hasMore: options.length >= limit,
     };

--- a/app/client/src/routes/home.tsx
+++ b/app/client/src/routes/home.tsx
@@ -511,6 +511,7 @@ function FilterFieldInputs({
             ? sourceState[sourceFieldConfig.id]
             : null;
           const selectProps = {
+            additionalOptions: 'additionalOptions' in fieldConfig ? fieldConfig.additionalOptions : [],
             apiKey,
             apiUrl,
             contextFilters: getContextFilters(
@@ -797,6 +798,7 @@ function SourceSelectFilter(props: SourceSelectFilterProps) {
 type FilterFunction = LoadOptions<Option, GroupBase<Option>, unknown>;
 
 function SelectFilter({
+  additionalOptions,
   apiKey,
   apiUrl,
   contextFilters,
@@ -819,6 +821,7 @@ function SelectFilter({
   // Create the filter function from the HOF
   const filterFunc: FilterFunction = useMemo(() => {
     return filterOptions({
+      additionalOptions,
       apiKey,
       apiUrl,
       defaultOption,
@@ -1363,6 +1366,7 @@ function createSourceReducer(sourceFields: SourceFields) {
 
 // Filters options that require fetching values from the database
 function filterDynamicOptions({
+  additionalOptions = [],
   apiKey,
   apiUrl,
   defaultOption,
@@ -1374,6 +1378,7 @@ function filterDynamicOptions({
   profile,
   secondaryFieldName,
 }: {
+  additionalOptions?: Option[];
   apiKey: string;
   apiUrl: string;
   defaultOption?: Option | null;
@@ -1422,7 +1427,7 @@ function filterDynamicOptions({
     return {
       options:
         !lastLoadedOption && defaultOption // only include default option in first page
-          ? [defaultOption, ...options]
+          ? [defaultOption, ...options, ...additionalOptions]
           : options,
       hasMore: options.length >= limit,
     };
@@ -1431,6 +1436,7 @@ function filterDynamicOptions({
 
 // Filters options by search input, returning a maximum number of options
 function filterOptions({
+  additionalOptions = [],
   apiKey,
   apiUrl,
   defaultOption,
@@ -1443,6 +1449,7 @@ function filterOptions({
   staticOptions,
   secondaryFieldName,
 }: {
+  additionalOptions?: Option[];
   apiKey: string;
   apiUrl: string;
   defaultOption?: Option | null;
@@ -1462,6 +1469,7 @@ function filterOptions({
     );
   } else {
     return filterDynamicOptions({
+      additionalOptions,
       apiKey,
       apiUrl,
       defaultOption,
@@ -1979,6 +1987,7 @@ type RangeFilterProps = {
 };
 
 type SelectFilterProps = {
+  additionalOptions?: Option[];
   apiKey: string;
   apiUrl: string;
   contextFilters: FilterQueryData;

--- a/app/server/app/content/config/fields.json
+++ b/app/server/app/content/config/fields.json
@@ -380,6 +380,9 @@
       "key": "reportingCycle",
       "label": "Reporting Cycle",
       "type": "select",
+      "additionalOptions": [
+        { "value": -1, "label": "Any" }
+      ],
       "default": { "value": "", "label": "Latest" },
       "direction": "desc",
       "contextFields": ["organizationId", "region", "state"]

--- a/app/server/app/content/swagger/api-public.json
+++ b/app/server/app/content/swagger/api-public.json
@@ -4233,6 +4233,7 @@
         "in": "query",
         "example": 2020,
         "explode": true,
+        "description": "Filter the summary to a specific reporting cycle in terms of the four-digit year the reporting cycle ended (e.g., for the 4/2/2016 – 3/31/2018 reporting cycle, the four-digit reporting cycle is “2018”). If left blank, the service will return the most recent cycle. If -1 is used, the service will return all reporting cycles.",
         "schema": {
           "type": "integer"
         }

--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -321,15 +321,19 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
   // so that we can apply the same filters to the subquery
   const latestColumn = profile.columns.find((col) => col.default === 'latest');
   const subQuery =
-    latestColumn && !queryParams.filters.hasOwnProperty(latestColumn.alias)
-      ? createLatestSubquery(
-          req,
-          profile,
-          queryParams,
-          latestColumn.name,
-          latestColumn.type,
-        )
-      : null;
+    latestColumn &&
+    queryParams.filters.hasOwnProperty(latestColumn.alias) &&
+    queryParams.filters[latestColumn.alias] === -1
+      ? null
+      : latestColumn && !queryParams.filters.hasOwnProperty(latestColumn.alias)
+        ? createLatestSubquery(
+            req,
+            profile,
+            queryParams,
+            latestColumn.name,
+            latestColumn.type,
+          )
+        : null;
 
   // build select statement of the query
   if (!countOnly) {
@@ -353,6 +357,9 @@ function parseCriteria(req, query, profile, queryParams, countOnly = false) {
 
   // build where clause of the query
   profile.columns.forEach((col) => {
+    if (col.default === 'latest' && queryParams.filters[col.alias] === -1)
+      return;
+
     const lowArg = 'lowParam' in col && queryParams.filters[col.lowParam];
     const highArg = 'highParam' in col && queryParams.filters[col.highParam];
     const exactArg = queryParams.filters[col.alias];


### PR DESCRIPTION
## Related Issues:
* [EQ-428](https://jira.epa.gov/browse/EQ-428)

## Main Changes:
* Added an "Any" query option for the Reporting Cycle filter.

## Steps To Test:
1. Update your envs to connect to the EQ dev database
2. Navigate to http://localhost:3000/attains/assessments
3. Turn off the assessment unit status  filter
4. Click Download
5. Verify the count is around 2,598,888
6. Select "Any" in the reporting cycle filter
7. Click Download
8. Verify the count is around 8,256,049
9. Select "2014" in the reporting cycle filter
10. Click Download
11. Verify the count is around 1,325,469
