### PR TITLE
Hide Action Documents profile from National Downloads page

### DIFF
--- a/app/client/src/contexts/content.tsx
+++ b/app/client/src/contexts/content.tsx
@@ -76,6 +76,7 @@ export type Content = {
       description: string;
       columns: Array<ColumnConfig>;
       label: string;
+      provideBulkDownload: boolean;
       resource: string;
     };
   };

--- a/app/client/src/routes/nationalDownloads.tsx
+++ b/app/client/src/routes/nationalDownloads.tsx
@@ -110,6 +110,11 @@ function NationalDownloadsData({
         <tbody>
           {Object.entries(content.data.metadata)
             .sort((a, b) => a[0].localeCompare(b[0]))
+            .filter(([profile]) => {
+              const config = content.data.profileConfig[profile];
+              if (config?.provideBulkDownload) return true;
+              return false;
+            })
             .map(([profile, fileInfo]) => (
               <tr key={profile}>
                 <th scope="row" data-label="Download link (CSV ZIP)">

--- a/app/server/app/content/config/profiles.json
+++ b/app/server/app/content/config/profiles.json
@@ -28,6 +28,7 @@
       { "key": "planSummaryLink" }
     ],
     "label": "Actions",
+    "provideBulkDownload": true,
     "resource": "actions"
   },
   "actionDocuments": {
@@ -171,6 +172,7 @@
       { "key": "waterSizeUnits" }
     ],
     "label": "Assessments",
+    "provideBulkDownload": true,
     "resource": "assessments"
   },
   "assessmentUnits": {
@@ -199,6 +201,7 @@
       { "key": "waterSizeUnits" }
     ],
     "label": "Assessment Units",
+    "provideBulkDownload": true,
     "resource": "assessmentUnits"
   },
   "assessmentUnitsMonitoringLocations": {
@@ -228,6 +231,7 @@
       { "key": "waterSizeUnits" }
     ],
     "label": "Assessment Units with Monitoring Locations",
+    "provideBulkDownload": true,
     "resource": "assessmentUnitsMonitoringLocations"
   },
   "catchmentCorrespondence": {
@@ -247,6 +251,7 @@
       { "key": "cycleId" }
     ],
     "label": "Catchment Correspondence",
+    "provideBulkDownload": true,
     "resource": "catchmentCorrespondence"
   },
   "sources": {
@@ -276,6 +281,7 @@
       { "key": "waterSizeUnits" }
     ],
     "label": "Sources",
+    "provideBulkDownload": true,
     "resource": "sources"
   },
   "tmdl": {
@@ -318,6 +324,7 @@
       { "key": "planSummaryLink" }
     ],
     "label": "Total Maximum Daily Load",
+    "provideBulkDownload": true,
     "resource": "tmdl"
   }
 }


### PR DESCRIPTION
## Related Issues:
* [EQ-461](https://jira.epa.gov/browse/EQ-461)

## Main Changes:
* Added logic to only show a profile on the National Downloads page if it is specified in the profile configuration.

## Steps to Test:

1. Add a row to the `logging.mv_profile_stats` table for the current schema and the `action_documents` profile (replacing the schema name with the currently active schema):
```sql
INSERT INTO logging.mv_profile_stats (profile_name, schema_name, num_rows, last_refresh_end_time, last_refresh_elapsed, csv_size, gz_size, zip_size, creation_date)
    VALUES ('action_documents', '<current_schema_name>', 32166, '2025-01-03T21:52:06.00+00:00', '0:00', 84719756, 9603977, 9604239, CURRENT_TIMESTAMP);
```
2. Go to http://localhost:3000/attains and expand the profile dropdown. The refresh date should show next to the Actions Document Search option.
3. Go to http://localhost:3000/national-downloads. The Action Documents profile should **not** show in the table.