### PR TITLE
Fixed an incorrect example in api-public.json

### DIFF
--- a/app/server/app/content/swagger/api-public.json
+++ b/app/server/app/content/swagger/api-public.json
@@ -4471,7 +4471,7 @@
       "documentQueryParam": {
         "name": "documentQuery",
         "in": "query",
-        "example": ["Tuscumbia River Canal"],
+        "example": "Tuscumbia River Canal",
         "schema": {
           "type": "string"
         }


### PR DESCRIPTION
## Related Issues:
* [EQ-464](https://jira.epa.gov/browse/EQ-464)

## Main Changes:
* Fixed an incorrect example in `api-public.json`.

## Steps To Test:
1. Go to http://localhost:3000/api-documentation#/ATTAINS%20-%20Action%20Documents/get_attains_actionDocuments. Confirm the example for `documentQuery` is a string.