### PR TITLE
Added catch block to Glossary ETL

### DIFF
--- a/app/server/app/routes/health.js
+++ b/app/server/app/routes/health.js
@@ -31,11 +31,10 @@ export default function (app, basePath) {
 
     try {
       // check etl status in db
-      const results =
-        (await queryPool(
-          knex.withSchema('logging').from('etl_status').select('glossary'),
-        ),
-        true);
+      const results = await queryPool(
+        knex.withSchema('logging').from('etl_status').select('glossary'),
+        true,
+      );
       if (results.glossary === 'failed') {
         return res.status(200).json({ status: 'FAILED-DB' });
       }

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -296,6 +296,9 @@ export async function syncGlossary(s3Config, retryCount = 0) {
     await uploadFilePublic('glossary.json', JSON.stringify(terms));
 
     await updateEtlStatus(pool, 'glossary', 'success');
+  } catch (err) {
+    log.warn(`Sync Glossary failed! ${err}`);
+    await updateEtlStatus(pool, 'glossary', 'failed');
   } finally {
     await endConnPool(pool);
   }


### PR DESCRIPTION
## Related Issues:
* [EQ-488](https://jira.epa.gov/browse/EQ-488)

## Main Changes:
* Added back the catch block in the Glossary ETL. This block logs the error and updates the "glossary" task to the "failed" status.

## Steps To Test:
1. Update the "glossaryURL" entry in `services.json` to a non-existent URL.
2. Run the glossary ETL with the command `npm run etl_glossary`.
3. Confirm the task prints "Non-200 response returned from Glossary service, retrying" 5 times before failing.
4. Confirm the `glossary` column in `logging.etl_status` is set to "failed".