### PR TITLE
Bugfix/495 action documents sorting

### DIFF
--- a/app/client/src/components/previewModal.tsx
+++ b/app/client/src/components/previewModal.tsx
@@ -43,9 +43,9 @@ export function PreviewModal<D extends QueryData>({
       return [
         {
           id: RANK_KEY,
-          name: 'Rank (%)',
+          name: 'Match (%)',
           sortable: true,
-          width: 100,
+          width: 105,
         },
         ...columnDefs,
       ];

--- a/app/client/src/components/table.tsx
+++ b/app/client/src/components/table.tsx
@@ -47,7 +47,7 @@ export const Table = ({
   };
 
   const [sortDir, setSortDir] = useState<'ascending' | 'descending'>(
-    getSortDirection(initialSortDir), // FIXME: This is a bug (possible race condition with `epa.js`), it should be `initialSortDir`
+    initialSortDir,
   );
   const [sortIndex, setSortIndex] = useState(initialSortIndex);
 


### PR DESCRIPTION
## Related Issues:
* [EQ-495](https://jira.epa.gov/browse/EQ-495)

## Main Changes:
* Updated the logic for determining the default sort direction in the Action Documents preview table.
  - There had been an issue with this in the Table component in the past so a workaround was implemented, but it looks like that workaround is now causing the reverse behavior.
- Updated the search rank's column name from "Rank (%)" to "Match (%)".

## Steps To Test:
1. Go to http://localhost:3000/attains/actionDocuments.
2. In the **Search Text / Keyword** text box, enter a search term, e.g. "assessments".
3. Click the "Preview" button.
4. In the results modal, verify the leftmost column name is "Match (%)" and that the values are sorted in descending order.
