### PR TITLE
bugfix/db pool causes app crash

### DIFF
--- a/app/server/app/utilities/database.js
+++ b/app/server/app/utilities/database.js
@@ -107,5 +107,8 @@ const pool = new pg.Pool({
   max: parseInt(process.env.DB_POOL_MAX),
   ssl: dbSsl ? { rejectUnauthorized: false } : undefined,
 });
+pool.on('error', (err, client) => {
+  log.error('Unexpected error in PostgreSQL connection pool', err);
+});
 
 export { appendToWhere, knex, pool, queryPool };


### PR DESCRIPTION
## Main Changes:
* Fixed an issue with errors in the connection pool crashing the app.

## Steps To Test:
1. Paste the below code in the bottom of the `app/server/app/utilties/database.js` file. 
2. Get prepared to restart the database service. 
    * In windows I found postgres in the services app and click the "restart" button.
3. Start the app
4. Verify you see the output of the fetch every 100ms
5. Restart the postgres service
6. Verify you see errors for a couple of seconds and then successful output of the fetch commands
7. Verify you can still use the app

```
const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
async function testCrash() {
  while (true) {
    try {
      const res = await fetch('http://localhost:3002/api/health/etlGlossary');
      console.log('res: ', await res.json());
    } catch (ex) {
      console.log(ex);
    }
    await delay(100);
  }
}

setTimeout(() => {
  testCrash();
}, 2000);
```

![image](https://github.com/user-attachments/assets/f5b3bcb1-ad61-452a-84b7-c0c1c1f4db44)
