### PR TITLE
feature/555 doc search issue

### DIFF
--- a/app/server/app/routes/attains.js
+++ b/app/server/app/routes/attains.js
@@ -444,16 +444,17 @@ function parseDocumentSearchCriteria(req, query, profile, queryParams) {
             .map((col) => col.name)
             .concat(
               knex.raw(
-                `ts_rank_cd(${documentQueryColumn.name}, websearch_to_tsquery(?), 1 | 32) AS rank`,
+                `ts_rank_cd(${documentQueryColumn.name}, websearch_to_tsquery('english', ?), 1 | 32) AS rank`,
                 [documentQuery],
               ),
             ),
         )
           .withSchema(req.activeSchema)
           .from(target.tableName ?? target.name)
-          .whereRaw(`${documentQueryColumn.name} @@ websearch_to_tsquery(?)`, [
-            documentQuery,
-          ]);
+          .whereRaw(
+            `${documentQueryColumn.name} @@ websearch_to_tsquery('english', ?)`,
+            [documentQuery],
+          );
       })
       .withSchema()
       .from('ranked')


### PR DESCRIPTION
## Related Issues:
* [EQ-555](https://jira.epa.gov/browse/EQ-555)

## Main Changes:
* Fixed doc search not picking up on acronyms.

## Steps To Test:
1. Navigate to http://localhost:3000/attains/actionDocuments
2. Search for `HAWQS`

