### PR TITLE
Feature/532 add s3 row count check

### DIFF
--- a/etl/app/content-private/config.json
+++ b/etl/app/content-private/config.json
@@ -1,7 +1,7 @@
 {
   "chunkSize": 5000,
   "gisChunkSize": 2000,
-  "retryLimit": 5,
+  "retryLimit": 15,
   "retryIntervalSeconds": 5,
   "retryIntervalProfileStatsSeconds": 60,
   "schemaRetentionDays": 21,

--- a/etl/app/content-private/services.json
+++ b/etl/app/content-private/services.json
@@ -2,8 +2,10 @@
   "attainsGis": {
     "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
   },
-  "domainValues": "https://attains.epa.gov/attains-public/api/domains",
+  "attains": {
+    "apiKey": "VgIEg4j6FpfGKq7jVfEsLRcT3mVze1ERIzi3e4vj",
+    "serviceUrl": "https://api.epa.gov/attains/"
+  },
   "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/vocabs/name/Expert%20Query%20Glossary/terms/full",
-  "materializedViews": "https://ordspub.epa.gov/ords/ow/attains_eq",
-  "stateCodes": "https://api.epa.gov/attains/states?api_key=VgIEg4j6FpfGKq7jVfEsLRcT3mVze1ERIzi3e4vj"
+  "materializedViews": "https://ordspub.epa.gov/ords/ow/attains_eq"
 }

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -435,7 +435,7 @@ async function logEtlExtractError(pool, etlLogId, extractError) {
   try {
     await pool.query(
       'UPDATE logging.etl_log SET extract_error = $1 WHERE id = $2',
-      [JSON.stringify(extractError), etlLogId],
+      [extractError, etlLogId],
     );
     log.info('ETL extract errors logged');
   } catch (err) {
@@ -1352,10 +1352,20 @@ export async function isDataReady(pool) {
     });
 
     if (ready.problems.length > 0) {
-      await logEtlExtractError(pool, etlLogId, ready.problems);
+      await logEtlExtractError(pool, etlLogId, JSON.stringify(ready.problems));
       ready.problems.forEach((problem) => {
         log.error(`Error Building MV Backups: ${problem}`);
       });
+    }
+
+    // verify each profile has at least 1 row
+    const emptyProfiles = ready.details.filter((i) => i.num_rows === 0);
+    if (emptyProfiles.length > 0) {
+      const emptyProfileNames = emptyProfiles.map((p) => p.name).join(', ');
+      const errorMessage = `The following profiles are empty: ${emptyProfileNames}`;
+      log.error(errorMessage);
+      await logEtlExtractError(pool, etlLogId, errorMessage);
+      return { ready: false, julian, logId: etlLogId };
     }
 
     if (ready.ready === 'go') return { ready: true, julian, logId: etlLogId };

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -548,12 +548,18 @@ export async function getActiveSchema(pool) {
 }
 
 async function fetchStateValues(s3Config, retryCount = 0) {
+  const apiKey = s3Config.services.attains.apiKey;
   const res = await fetchRetry({
-    url: s3Config.services.stateCodes,
+    url: `${s3Config.services.attains.serviceUrl}states`,
     s3Config,
     serviceName: 'States',
     callOptions: {
       timeout: s3Config.config.webServiceTimeout,
+      headers: apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
     },
   });
 

--- a/etl/app/server/database.js
+++ b/etl/app/server/database.js
@@ -6,7 +6,12 @@ import { setTimeout } from 'timers/promises';
 // utils
 import { fetchRetry, getEnvironment } from './utilities/index.js';
 import { log } from './utilities/logger.js';
-import { deleteDirectory, readS3File, syncDomainValues } from './s3.js';
+import {
+  deleteDirectory,
+  fetchStateValues,
+  readS3File,
+  syncDomainValues,
+} from './s3.js';
 
 const { Client, Pool } = pg;
 const pgp = pgPromise({ capSQL: true });
@@ -547,31 +552,23 @@ export async function getActiveSchema(pool) {
   return schemas.rows[0].schema_name;
 }
 
-async function fetchStateValues(s3Config, retryCount = 0) {
-  const apiKey = s3Config.services.attains.apiKey;
-  const res = await fetchRetry({
-    url: `${s3Config.services.attains.serviceUrl}states`,
-    s3Config,
-    serviceName: 'States',
-    callOptions: {
-      timeout: s3Config.config.webServiceTimeout,
-      headers: apiKey
-        ? {
-            'X-Api-Key': apiKey,
-          }
-        : {},
-    },
-  });
-
-  return res.data.data;
-}
-
 async function loadStatesTable(pool, s3Config, schemaName) {
   const client = await pool.connect();
   try {
     const uniqueCodes = new Set();
-    const states = (await fetchStateValues(s3Config)).filter((state) => {
-      return uniqueCodes.has(state.code) ? false : uniqueCodes.add(state.code);
+    const statesFromS3 = await readS3File({
+      bucketInfo: {
+        accessKeyId: process.env.CF_S3_PUB_ACCESS_KEY,
+        bucketId: process.env.CF_S3_PUB_BUCKET_ID,
+        region: process.env.CF_S3_PUB_REGION,
+        secretAccessKey: process.env.CF_S3_PUB_SECRET_KEY,
+      },
+      path: `content-etl/domainValues/state.json`,
+    });
+    const states = statesFromS3.state.filter((state) => {
+      return uniqueCodes.has(state.value)
+        ? false
+        : uniqueCodes.add(state.value);
     });
 
     await client.query('BEGIN');
@@ -588,7 +585,7 @@ async function loadStatesTable(pool, s3Config, schemaName) {
     for (const state of states) {
       await client.query(
         'INSERT INTO states(statecode, statename) VALUES ($1, $2)',
-        [state.code, state.name],
+        [state.value, state.label],
       );
     }
     await client.query('COMMIT');
@@ -761,6 +758,16 @@ export async function runLoad(pool, s3Config, s3Julian, logId) {
 
   try {
     const schemaId = await createNewSchema(pool, schemaName, s3Julian, logId);
+
+    // Attempt to refresh the states file in s3.
+    // If it fails continue with old states file in s3.
+    try {
+      await fetchStateValues(pool, s3Config);
+    } catch (err) {
+      console.warn(
+        `Failed to fetch state values, continuing ETL process: ${err}`,
+      );
+    }
 
     // Load tables first that will be used when creating profile materialized views
     await loadUtilityTables(pool, s3Config, schemaName);

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -141,11 +141,20 @@ export async function uploadFilePublic(
 
 // Sync the domain values corresponding to a single domain name
 async function fetchSingleDomain(name, mapping, pool, s3Config) {
+  const apiKey = s3Config.services.attains.apiKey;
+  const url = `${s3Config.services.attains.serviceUrl}domains`;
   const res = await fetchRetry({
-    url: `${s3Config.services.domainValues}?domainName=${mapping.domainName}`,
+    url: `${url}?domainName=${mapping.domainName}`,
     s3Config,
     serviceName: `Domain Values (${mapping.domainName})`,
-    callOptions: { timeout: s3Config.config.webServiceTimeout },
+    callOptions: {
+      timeout: s3Config.config.webServiceTimeout,
+      headers: apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    },
   });
 
   const valuesAdded = new Set();
@@ -219,12 +228,18 @@ export async function syncDomainValues(s3Config, poolParam = null) {
 
 // Sync state codes and labels from the states service
 async function fetchStateValues(pool, s3Config) {
+  const apiKey = s3Config.services.attains.apiKey;
   const res = await fetchRetry({
-    url: s3Config.services.stateCodes,
+    url: `${s3Config.services.attains.serviceUrl}states`,
     s3Config,
     serviceName: 'States',
     callOptions: {
       timeout: s3Config.config.webServiceTimeout,
+      headers: apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
     },
   });
 

--- a/etl/app/server/s3.js
+++ b/etl/app/server/s3.js
@@ -227,7 +227,7 @@ export async function syncDomainValues(s3Config, poolParam = null) {
 }
 
 // Sync state codes and labels from the states service
-async function fetchStateValues(pool, s3Config) {
+export async function fetchStateValues(pool, s3Config) {
   const apiKey = s3Config.services.attains.apiKey;
   const res = await fetchRetry({
     url: `${s3Config.services.attains.serviceUrl}states`,


### PR DESCRIPTION
## Related Issues:
* [EQ-532](https://jira.epa.gov/browse/EQ-532)
* [EQ-537](https://jira.epa.gov/browse/EQ-537)
* [EQ-559](https://jira.epa.gov/browse/EQ-559)

## Main Changes:
* Added a row check to the start of the ETL. This ensures all profiles in the s3 bucket have data prior to trying to load the data.
* Added an API key for the attains domain services.
* Increased the web service retry limit in the ETL.
* Updated the ETL to fallback to using the state.json file in the S3 bucket if the service is down.

